### PR TITLE
Final adjustments to move from GitLab to GitHub

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -138,9 +138,9 @@ replaces the original templates from the [openapi-python-client](https://github.
 
 5) Push to branch
 
-6) confirm branch passes CI - ***do not raise an MR if CI does not pass***
+6) confirm branch passes CI - ***do not raise an PR if CI does not pass***
 
-7) raise MR against master ensuring good title/description and bullet point
+7) raise PR against master ensuring good title/description and bullet point
    all significant commits
 
 ## Release
@@ -194,13 +194,13 @@ patch release is prefered.
     * create a new branch
     * increment the patch part of the version in all necessary places (eg. x.x.1 -> x.x.2)
     * commit and push the changes
-    * open merge request creation in browser
+    * open pull request creation in browser
 
-4) Confirm MR creation opened by the relase script
+4) Confirm PR creation opened by the relase script
 
 5) Confirm CI passes
 
-6) Merge MR
+6) Merge PR
 
 7) Tag new release in git - this will trigger the build and upload to PyPI
     ```
@@ -219,7 +219,7 @@ When new major/minor OSIDB version is released, major/minor release of the osidb
     $ git pull
     ```
 
-2) Start release script and follow instructions (GitLab token will be needed to access GitLab API)
+2) Start release script and follow instructions
 
     ```
     $ make release
@@ -232,13 +232,13 @@ When new major/minor OSIDB version is released, major/minor release of the osidb
     * regenerate bindings
     * replace version on all places with new OSIDB bindings based on the latest OSIDB version
     * commit and push the changes
-    * open merge request creation in browser
+    * open pull request creation in browser
 
-3) Confirm MR creation opened by the relase script
+3) Confirm PR creation opened by the relase script
 
 4) Confirm CI passes
 
-5) Merge MR
+5) Merge PR
 
 6) Tag new release in git - this will trigger the build and upload to PyPI
     ```

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -15,14 +15,14 @@ You can install the bindings via Python 3 pip:
     ```
     pip install osidb-bindings
     ```
-* directly from the [GitLab](https://git.prodsec.redhat.com/devops/osidb-bindings) repository (will install the version
+* directly from the [GitHub](https://github.com/RedHatProductSecurity/osidb-bindings) repository (will install the version
     from master branch)
     ```
-    pip install -e git+https://git.prodsec.redhat.com/devops/osidb-bindings.git#egg=osidb_bindings
+    pip install -e git+https://github.com/RedHatProductSecurity/osidb-bindings.git#egg=osidb_bindings
     ```
-* OPTIONAL - directly from the [GitLab](https://git.prodsec.redhat.com/devops/osidb-bindings) repository with branch specification
+* OPTIONAL - directly from the [GitHub](https://github.com/RedHatProductSecurity/osidb-bindings) repository with branch specification
     ```
-    pip install -e git+https://git.prodsec.redhat.com/devops/osidb-bindings.git@<branch_name>#egg=osidb_bindings
+    pip install -e git+https://github.com/RedHatProductSecurity/osidb-bindings.git@<branch_name>#egg=osidb_bindings
     ```
 
 ## OSIDB Compatibility

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -90,17 +90,17 @@ push_branch() {
 
 # Commit changed files
 # $1: version
-merge_request() {
+pull_request() {
     local version="${1}"
 
-    base_link="https://git.prodsec.redhat.com/devops/osidb-bindings/merge_requests/new"
-    url_with_args="${base_link}?merge_request%5Bsource_branch%5D=v${version}&merge_request%5Btitle%5D=preparation%20of%20${version}%20release"
-    echo "Trying to open the following link in browser to create a merge request into the master branch:"
+    base_link="https://github.com/RedHatProductSecurity/osidb-bindings/pull/new"
+    url_with_args="${base_link}/v${version}?pull_request%5Btitle%5D=preparation%20of%20${version}%20release"
+    echo "Trying to open the following link in browser to create a pull request into the master branch:"
     echo
     echo "    ${url_with_args}"
     echo
     xdg-open "${url_with_args}" || (
-        echo "Failed to open URL to create merge request automatically."
+        echo "Failed to open URL to create pull request automatically."
         echo "Please open URL manually in your browser"
         echo
     )

--- a/scripts/patch_release.sh
+++ b/scripts/patch_release.sh
@@ -32,6 +32,6 @@ review
 
 commit ${new_version}
 push_branch "v${new_version}"
-merge_request ${new_version}
+pull_request ${new_version}
 
 exit 0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -80,7 +80,7 @@ get_new_version() {
     echo
 }
 
-# Get OpenAPI schema from gitlab API
+# Get OpenAPI schema from github API
 # $1: version
 get_schema() {
     local version=$1
@@ -114,6 +114,6 @@ review
 commit_version_changes ${new_version}
 
 push_branch "v${new_version}"
-merge_request ${new_version}
+pull_request ${new_version}
 
 exit 0


### PR DESCRIPTION
Mostly terminology (merge request to pull request) and URLs changes so everything now corresponds and points to the github.

Closes OSIDB-381