### PR TITLE
Release scripts fix

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -56,6 +56,16 @@ update_version() {
     echo "Updating the CHANGELOG.md to ${version}"
     sed -i 's/^## Unreleased.*/## Unreleased\n\n## ['"${version}"'] - '$(date '+%Y-%m-%d')'/' CHANGELOG.md
 
+    echo
+}
+
+# Update the version in API schema file
+# $1: new version
+update_schema_version() {
+    local version=$1
+
+    echo
+
     echo "Replacing version in OpenAPI schema (if not already updated from the OSIDB repository) to ${version}"
     sed -i 's/version: [0-9]*\.[0-9]*\.[0-9]*/version: '${version}'/g' osidb_bindings/openapi_schema.yml
 

--- a/scripts/pre_release.sh
+++ b/scripts/pre_release.sh
@@ -65,6 +65,7 @@ review
 commit_bindings_changes ${new_version}
 
 update_version ${new_version}
+update_schema_version ${new_version}
 review
 commit_version_changes ${new_version}
 


### PR DESCRIPTION
Changed the way the version in OpenAPI schema file is updated so it happens only during the pre-release, see the commit description for more detailed reasoning.