### PR TITLE
Various bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- fix missing aiohttp dependency in setup script
 ## [3.4.1] - 2023-08-23
 ### Added
 - async iterator operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - fix missing aiohttp dependency in setup script
+- fix aiohttp error when `BUGZILLA_API_KEY` environmental variable
+  is not supplied
+- fix error caused by supplying empty limit to async iterator
 ## [3.4.1] - 2023-08-23
 ### Added
 - async iterator operation

--- a/osidb_bindings/constants.py
+++ b/osidb_bindings/constants.py
@@ -9,9 +9,11 @@ OSIDB_API_VERSION: str = "v1"
 OSIDB_BINDINGS_VERSION: str = "3.4.1"
 OSIDB_BINDINGS_USERAGENT: str = f"osidb-bindings-{OSIDB_BINDINGS_VERSION}"
 OSIDB_BINDINGS_API_PATH: str = ".bindings.python_client.api.osidb"
-OSIDB_BINDINGS_PLACEHOLDER_FIELD = (
+OSIDB_BINDINGS_PLACEHOLDER_FIELD: str = (
     f'__placeholder_field{OSIDB_BINDINGS_VERSION.replace(".","")}'
 )
+
+DEFAULT_LIMIT: int = 50
 
 # all available session operations
 ALL_SESSION_OPERATIONS: List[str] = (

--- a/osidb_bindings/iterators.py
+++ b/osidb_bindings/iterators.py
@@ -6,6 +6,7 @@ import re
 from functools import partial
 from typing import Callable, Optional
 
+from .constants import DEFAULT_LIMIT
 from .exceptions import OSIDBBindingsException
 
 
@@ -23,7 +24,7 @@ class Paginator:
         self,
         *args,
         retrieve_list_fn: Optional[Callable] = None,
-        limit: int = 50,
+        limit: int = DEFAULT_LIMIT,
         offset: int = 0,
         init_response=None,
         **kwargs,

--- a/osidb_bindings/session.py
+++ b/osidb_bindings/session.py
@@ -4,7 +4,6 @@ osidb-bindings session
 
 import asyncio
 import importlib
-import os
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional
 
@@ -116,7 +115,7 @@ class Session:
             base_url=base_url,
             headers={
                 "User-Agent": OSIDB_BINDINGS_USERAGENT,
-                "Bugzilla-Api-Key": os.getenv("BUGZILLA_API_KEY"),
+                "Bugzilla-Api-Key": get_env("BUGZILLA_API_KEY", ""),
             },
             verify_ssl=verify_ssl,
         )

--- a/osidb_bindings/session.py
+++ b/osidb_bindings/session.py
@@ -21,6 +21,7 @@ from .bindings.python_client.api.auth import (
 from .bindings.python_client.types import UNSET
 from .constants import (
     ALL_SESSION_OPERATIONS,
+    DEFAULT_LIMIT,
     OSIDB_API_VERSION,
     OSIDB_BINDINGS_API_PATH,
     OSIDB_BINDINGS_PLACEHOLDER_FIELD,
@@ -434,7 +435,7 @@ class SessionOperationsGroup:
             async_fn = get_async_function(method_module)
 
             kwargs.pop("offset", None)
-            limit = kwargs.pop("limit", 50)
+            limit = kwargs.pop("limit", None) or DEFAULT_LIMIT
             results_count = max_results or self.count(*args, **kwargs)
 
             connector = aiohttp.TCPConnector(limit=MAX_CONCURRENCY)

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,11 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.6",
-    install_requires=["attrs", "requests", "requests-gssapi", "python-dateutil"],
+    install_requires=[
+        "aiohttp",
+        "attrs",
+        "requests",
+        "requests-gssapi",
+        "python-dateutil",
+    ],
 )


### PR DESCRIPTION
This PR :

- adds missing `aiohttp` dependency into `setup.py` script. In #26 it was added only into the internal requirements file which does not drive the dependencies which are installed during the installation from PYPI. This is another evidence why we should invest some more time into the dependency handling (this applies also for griffon and component-registry-bindings).
- fixes error caused by `aiohttp` when `BUGZILLA_API_KEY` env variable was not set
- fixes error caused supplying the `None` value limit to async list iterator