### PR TITLE
Fix async list iterator max_results parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+- fix bindings making lot a of uncessary calls when supplying max_results
+  parameter for async list iterator which is much higher than actual results count
 ## [3.4.2] - 2023-08-24
 ### Changed
 - fix missing aiohttp dependency in setup script


### PR DESCRIPTION
This PR fixes the case when supplied `max_results` parameter was higher than the actual number of results which resulted in many unnecessary calls.