### PR TITLE
Fix to_dict transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+### Fixed
+- fix `to_dict` not being able corretly transform UNSET values
+  of different instances (mainly multiprocessing issue)
 
 ## [3.4.3] - 2023-08-25
+### Fixed
 - fix bindings making lot a of uncessary calls when supplying max_results
   parameter for async list iterator which is much higher than actual results count
 ## [3.4.2] - 2023-08-24

--- a/osidb_bindings/bindings/python_client/models/affect.py
+++ b/osidb_bindings/bindings/python_client/models/affect.py
@@ -127,41 +127,41 @@ class Affect(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if delegated_resolution is not UNSET:
+        if isinstance(delegated_resolution, Unset):
             field_dict["delegated_resolution"] = delegated_resolution
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
 
         return field_dict
@@ -286,41 +286,41 @@ class Affect(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if delegated_resolution is not UNSET:
+        if isinstance(delegated_resolution, Unset):
             field_dict["delegated_resolution"] = delegated_resolution
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/affect_meta_attr.py
+++ b/osidb_bindings/bindings/python_client/models/affect_meta_attr.py
@@ -37,25 +37,25 @@ class AffectMetaAttr(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if module_name is not UNSET:
+        if isinstance(module_name, Unset):
             field_dict["module_name"] = module_name
-        if module_stream is not UNSET:
+        if isinstance(module_stream, Unset):
             field_dict["module_stream"] = module_stream
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/affect_post.py
+++ b/osidb_bindings/bindings/python_client/models/affect_post.py
@@ -122,39 +122,39 @@ class AffectPost(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if delegated_resolution is not UNSET:
+        if isinstance(delegated_resolution, Unset):
             field_dict["delegated_resolution"] = delegated_resolution
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
 
         return field_dict
@@ -275,39 +275,39 @@ class AffectPost(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if delegated_resolution is not UNSET:
+        if isinstance(delegated_resolution, Unset):
             field_dict["delegated_resolution"] = delegated_resolution
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/affect_post_meta_attr.py
+++ b/osidb_bindings/bindings/python_client/models/affect_post_meta_attr.py
@@ -37,25 +37,25 @@ class AffectPostMetaAttr(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if module_name is not UNSET:
+        if isinstance(module_name, Unset):
             field_dict["module_name"] = module_name
-        if module_stream is not UNSET:
+        if isinstance(module_stream, Unset):
             field_dict["module_stream"] = module_stream
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/affect_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/affect_report_data.py
@@ -67,15 +67,15 @@ class AffectReportData(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/auth_token_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_create_response_200.py
@@ -38,21 +38,21 @@ class AuthTokenCreateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if username is not UNSET:
+        if isinstance(username, Unset):
             field_dict["username"] = username
-        if password is not UNSET:
+        if isinstance(password, Unset):
             field_dict["password"] = password
-        if access is not UNSET:
+        if isinstance(access, Unset):
             field_dict["access"] = access
-        if refresh is not UNSET:
+        if isinstance(refresh, Unset):
             field_dict["refresh"] = refresh
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/auth_token_refresh_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_refresh_create_response_200.py
@@ -34,17 +34,17 @@ class AuthTokenRefreshCreateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if access is not UNSET:
+        if isinstance(access, Unset):
             field_dict["access"] = access
-        if refresh is not UNSET:
+        if isinstance(refresh, Unset):
             field_dict["refresh"] = refresh
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/auth_token_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_retrieve_response_200.py
@@ -34,17 +34,17 @@ class AuthTokenRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if access is not UNSET:
+        if isinstance(access, Unset):
             field_dict["access"] = access
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if refresh is not UNSET:
+        if isinstance(refresh, Unset):
             field_dict["refresh"] = refresh
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/auth_token_verify_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_verify_create_response_200.py
@@ -32,15 +32,15 @@ class AuthTokenVerifyCreateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if token is not UNSET:
+        if isinstance(token, Unset):
             field_dict["token"] = token
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200.py
@@ -46,15 +46,15 @@ class CollectorsApiV1StatusRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if collectors is not UNSET:
+        if isinstance(collectors, Unset):
             field_dict["collectors"] = collectors
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item.py
@@ -71,19 +71,19 @@ class CollectorsApiV1StatusRetrieveResponse200CollectorsItem(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if data is not UNSET:
+        if isinstance(data, Unset):
             field_dict["data"] = data
-        if depends_on is not UNSET:
+        if isinstance(depends_on, Unset):
             field_dict["depends_on"] = depends_on
-        if error is not UNSET:
+        if isinstance(error, Unset):
             field_dict["error"] = error
-        if is_complete is not UNSET:
+        if isinstance(is_complete, Unset):
             field_dict["is_complete"] = is_complete
-        if data_models is not UNSET:
+        if isinstance(data_models, Unset):
             field_dict["data_models"] = data_models
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if updated_until is not UNSET:
+        if isinstance(updated_until, Unset):
             field_dict["updated_until"] = updated_until
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/collectors_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_healthy_retrieve_response_200.py
@@ -30,13 +30,13 @@ class CollectorsHealthyRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/collectors_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_retrieve_response_200.py
@@ -35,15 +35,15 @@ class CollectorsRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if index is not UNSET:
+        if isinstance(index, Unset):
             field_dict["index"] = index
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/comment.py
+++ b/osidb_bindings/bindings/python_client/models/comment.py
@@ -47,19 +47,19 @@ class Comment(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if external_system_id is not UNSET:
+        if isinstance(external_system_id, Unset):
             field_dict["external_system_id"] = external_system_id
-        if order is not UNSET:
+        if isinstance(order, Unset):
             field_dict["order"] = order
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/cv_ev_5_package_versions.py
+++ b/osidb_bindings/bindings/python_client/models/cv_ev_5_package_versions.py
@@ -30,9 +30,9 @@ class CVEv5PackageVersions(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if package is not UNSET:
+        if isinstance(package, Unset):
             field_dict["package"] = package
-        if versions is not UNSET:
+        if isinstance(versions, Unset):
             field_dict["versions"] = versions
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/cv_ev_5_versions.py
+++ b/osidb_bindings/bindings/python_client/models/cv_ev_5_versions.py
@@ -25,9 +25,9 @@ class CVEv5Versions(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
-        if status is not UNSET:
+        if isinstance(status, Unset):
             field_dict["status"] = status
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/epss.py
+++ b/osidb_bindings/bindings/python_client/models/epss.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
-from ..types import UNSET, OSIDBModel
+from ..types import UNSET, OSIDBModel, Unset
 
 T = TypeVar("T", bound="EPSS")
 
@@ -21,9 +21,9 @@ class EPSS(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if cve is not UNSET:
+        if isinstance(cve, Unset):
             field_dict["cve"] = cve
-        if epss is not UNSET:
+        if isinstance(epss, Unset):
             field_dict["epss"] = epss
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/erratum.py
+++ b/osidb_bindings/bindings/python_client/models/erratum.py
@@ -32,13 +32,13 @@ class Erratum(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if et_id is not UNSET:
+        if isinstance(et_id, Unset):
             field_dict["et_id"] = et_id
-        if advisory_name is not UNSET:
+        if isinstance(advisory_name, Unset):
             field_dict["advisory_name"] = advisory_name
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploit_only_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/exploit_only_report_data.py
@@ -48,17 +48,17 @@ class ExploitOnlyReportData(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if cve is not UNSET:
+        if isinstance(cve, Unset):
             field_dict["cve"] = cve
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if maturity_preliminary is not UNSET:
+        if isinstance(maturity_preliminary, Unset):
             field_dict["maturity_preliminary"] = maturity_preliminary
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if date is not UNSET:
+        if isinstance(date, Unset):
             field_dict["date"] = date
-        if reference is not UNSET:
+        if isinstance(reference, Unset):
             field_dict["reference"] = reference
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_collect_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_collect_update_response_200.py
@@ -32,15 +32,15 @@ class ExploitsApiV1CollectUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if result_cisa is not UNSET:
+        if isinstance(result_cisa, Unset):
             field_dict["result_cisa"] = result_cisa
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200.py
@@ -40,17 +40,17 @@ class ExploitsApiV1CveMapRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if cves is not UNSET:
+        if isinstance(cves, Unset):
             field_dict["cves"] = cves
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if page_size is not UNSET:
+        if isinstance(page_size, Unset):
             field_dict["page_size"] = page_size
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_epss_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_epss_list_response_200.py
@@ -48,21 +48,21 @@ class ExploitsApiV1EpssListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_flaw_data_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_flaw_data_list_response_200.py
@@ -48,21 +48,21 @@ class ExploitsApiV1FlawDataListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_data_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_data_list_response_200.py
@@ -48,21 +48,21 @@ class ExploitsApiV1ReportDataListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200.py
@@ -82,23 +82,23 @@ class ExploitsApiV1ReportDateRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if action_required is not UNSET:
+        if isinstance(action_required, Unset):
             field_dict["action_required"] = action_required
-        if cutoff_date is not UNSET:
+        if isinstance(cutoff_date, Unset):
             field_dict["cutoff_date"] = cutoff_date
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if evaluated_cves is not UNSET:
+        if isinstance(evaluated_cves, Unset):
             field_dict["evaluated_cves"] = evaluated_cves
-        if no_action is not UNSET:
+        if isinstance(no_action, Unset):
             field_dict["no_action"] = no_action
-        if not_relevant is not UNSET:
+        if isinstance(not_relevant, Unset):
             field_dict["not_relevant"] = not_relevant
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200.py
@@ -48,17 +48,17 @@ class ExploitsApiV1ReportExplanationsRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if explanations is not UNSET:
+        if isinstance(explanations, Unset):
             field_dict["explanations"] = explanations
-        if page_size is not UNSET:
+        if isinstance(page_size, Unset):
             field_dict["page_size"] = page_size
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200.py
@@ -48,17 +48,17 @@ class ExploitsApiV1ReportPendingRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if pending_actions is not UNSET:
+        if isinstance(pending_actions, Unset):
             field_dict["pending_actions"] = pending_actions
-        if pending_actions_count is not UNSET:
+        if isinstance(pending_actions_count, Unset):
             field_dict["pending_actions_count"] = pending_actions_count
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_status_retrieve_response_200.py
@@ -36,19 +36,19 @@ class ExploitsApiV1StatusRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if exploits_count is not UNSET:
+        if isinstance(exploits_count, Unset):
             field_dict["exploits_count"] = exploits_count
-        if exploits_count_relevant is not UNSET:
+        if isinstance(exploits_count_relevant, Unset):
             field_dict["exploits_count_relevant"] = exploits_count_relevant
-        if last_exploit is not UNSET:
+        if isinstance(last_exploit, Unset):
             field_dict["last_exploit"] = last_exploit
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_supported_products_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_supported_products_list_response_200.py
@@ -48,21 +48,21 @@ class ExploitsApiV1SupportedProductsListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw.py
+++ b/osidb_bindings/bindings/python_client/models/flaw.py
@@ -263,81 +263,81 @@ class Flaw(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if title is not UNSET:
+        if isinstance(title, Unset):
             field_dict["title"] = title
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if meta is not UNSET:
+        if isinstance(meta, Unset):
             field_dict["meta"] = meta
-        if comments is not UNSET:
+        if isinstance(comments, Unset):
             field_dict["comments"] = comments
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if package_versions is not UNSET:
+        if isinstance(package_versions, Unset):
             field_dict["package_versions"] = package_versions
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if requires_summary is not UNSET:
+        if isinstance(requires_summary, Unset):
             field_dict["requires_summary"] = requires_summary
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if cwe_id is not UNSET:
+        if isinstance(cwe_id, Unset):
             field_dict["cwe_id"] = cwe_id
-        if unembargo_dt is not UNSET:
+        if isinstance(unembargo_dt, Unset):
             field_dict["unembargo_dt"] = unembargo_dt
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if reported_dt is not UNSET:
+        if isinstance(reported_dt, Unset):
             field_dict["reported_dt"] = reported_dt
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if nvd_cvss2 is not UNSET:
+        if isinstance(nvd_cvss2, Unset):
             field_dict["nvd_cvss2"] = nvd_cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if nvd_cvss3 is not UNSET:
+        if isinstance(nvd_cvss3, Unset):
             field_dict["nvd_cvss3"] = nvd_cvss3
-        if is_major_incident is not UNSET:
+        if isinstance(is_major_incident, Unset):
             field_dict["is_major_incident"] = is_major_incident
-        if major_incident_state is not UNSET:
+        if isinstance(major_incident_state, Unset):
             field_dict["major_incident_state"] = major_incident_state
-        if nist_cvss_validation is not UNSET:
+        if isinstance(nist_cvss_validation, Unset):
             field_dict["nist_cvss_validation"] = nist_cvss_validation
 
         return field_dict
@@ -624,81 +624,81 @@ class Flaw(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if title is not UNSET:
+        if isinstance(title, Unset):
             field_dict["title"] = title
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if meta is not UNSET:
+        if isinstance(meta, Unset):
             field_dict["meta"] = meta
-        if comments is not UNSET:
+        if isinstance(comments, Unset):
             field_dict["comments"] = comments
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if package_versions is not UNSET:
+        if isinstance(package_versions, Unset):
             field_dict["package_versions"] = package_versions
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if requires_summary is not UNSET:
+        if isinstance(requires_summary, Unset):
             field_dict["requires_summary"] = requires_summary
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if cwe_id is not UNSET:
+        if isinstance(cwe_id, Unset):
             field_dict["cwe_id"] = cwe_id
-        if unembargo_dt is not UNSET:
+        if isinstance(unembargo_dt, Unset):
             field_dict["unembargo_dt"] = unembargo_dt
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if reported_dt is not UNSET:
+        if isinstance(reported_dt, Unset):
             field_dict["reported_dt"] = reported_dt
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if nvd_cvss2 is not UNSET:
+        if isinstance(nvd_cvss2, Unset):
             field_dict["nvd_cvss2"] = nvd_cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if nvd_cvss3 is not UNSET:
+        if isinstance(nvd_cvss3, Unset):
             field_dict["nvd_cvss3"] = nvd_cvss3
-        if is_major_incident is not UNSET:
+        if isinstance(is_major_incident, Unset):
             field_dict["is_major_incident"] = is_major_incident
-        if major_incident_state is not UNSET:
+        if isinstance(major_incident_state, Unset):
             field_dict["major_incident_state"] = major_incident_state
-        if nist_cvss_validation is not UNSET:
+        if isinstance(nist_cvss_validation, Unset):
             field_dict["nist_cvss_validation"] = nist_cvss_validation
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
@@ -40,21 +40,21 @@ class FlawAcknowledgment(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post.py
@@ -33,17 +33,17 @@ class FlawAcknowledgmentPost(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
 
         return field_dict
@@ -77,17 +77,17 @@ class FlawAcknowledgmentPost(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put.py
@@ -38,19 +38,19 @@ class FlawAcknowledgmentPut(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
 
         return field_dict
@@ -88,19 +88,19 @@ class FlawAcknowledgmentPut(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_classification.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_classification.py
@@ -25,9 +25,9 @@ class FlawClassification(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if workflow is not UNSET:
+        if isinstance(workflow, Unset):
             field_dict["workflow"] = workflow
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_comment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment.py
@@ -48,23 +48,23 @@ class FlawComment(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if text is not UNSET:
+        if isinstance(text, Unset):
             field_dict["text"] = text
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if external_system_id is not UNSET:
+        if isinstance(external_system_id, Unset):
             field_dict["external_system_id"] = external_system_id
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if order is not UNSET:
+        if isinstance(order, Unset):
             field_dict["order"] = order
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_comment_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment_post.py
@@ -43,17 +43,17 @@ class FlawCommentPost(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if text is not UNSET:
+        if isinstance(text, Unset):
             field_dict["text"] = text
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
 
         return field_dict
@@ -86,17 +86,17 @@ class FlawCommentPost(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if text is not UNSET:
+        if isinstance(text, Unset):
             field_dict["text"] = text
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_meta_attr.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_meta_attr.py
@@ -77,65 +77,65 @@ class FlawMetaAttr(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if acks_not_needed is not UNSET:
+        if isinstance(acks_not_needed, Unset):
             field_dict["acks_not_needed"] = acks_not_needed
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if alias is not UNSET:
+        if isinstance(alias, Unset):
             field_dict["alias"] = alias
-        if bz_datascore is not UNSET:
+        if isinstance(bz_datascore, Unset):
             field_dict["bz_datascore"] = bz_datascore
-        if bz_id is not UNSET:
+        if isinstance(bz_id, Unset):
             field_dict["bz_id"] = bz_id
-        if checklists is not UNSET:
+        if isinstance(checklists, Unset):
             field_dict["checklists"] = checklists
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss2_vector is not UNSET:
+        if isinstance(cvss2_vector, Unset):
             field_dict["cvss2_vector"] = cvss2_vector
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_comment is not UNSET:
+        if isinstance(cvss3_comment, Unset):
             field_dict["cvss3_comment"] = cvss3_comment
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if cvss3_vector is not UNSET:
+        if isinstance(cvss3_vector, Unset):
             field_dict["cvss3_vector"] = cvss3_vector
-        if cwe is not UNSET:
+        if isinstance(cwe, Unset):
             field_dict["cwe"] = cwe
-        if depends_on is not UNSET:
+        if isinstance(depends_on, Unset):
             field_dict["depends_on"] = depends_on
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if jira_trackers is not UNSET:
+        if isinstance(jira_trackers, Unset):
             field_dict["jira_trackers"] = jira_trackers
-        if mitigate is not UNSET:
+        if isinstance(mitigate, Unset):
             field_dict["mitigate"] = mitigate
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if public is not UNSET:
+        if isinstance(public, Unset):
             field_dict["public"] = public
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if related_cves is not UNSET:
+        if isinstance(related_cves, Unset):
             field_dict["related_cves"] = related_cves
-        if reported is not UNSET:
+        if isinstance(reported, Unset):
             field_dict["reported"] = reported
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if task_owner is not UNSET:
+        if isinstance(task_owner, Unset):
             field_dict["task_owner"] = task_owner
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_post.py
@@ -258,79 +258,79 @@ class FlawPost(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if title is not UNSET:
+        if isinstance(title, Unset):
             field_dict["title"] = title
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if meta is not UNSET:
+        if isinstance(meta, Unset):
             field_dict["meta"] = meta
-        if comments is not UNSET:
+        if isinstance(comments, Unset):
             field_dict["comments"] = comments
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if package_versions is not UNSET:
+        if isinstance(package_versions, Unset):
             field_dict["package_versions"] = package_versions
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if requires_summary is not UNSET:
+        if isinstance(requires_summary, Unset):
             field_dict["requires_summary"] = requires_summary
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if cwe_id is not UNSET:
+        if isinstance(cwe_id, Unset):
             field_dict["cwe_id"] = cwe_id
-        if unembargo_dt is not UNSET:
+        if isinstance(unembargo_dt, Unset):
             field_dict["unembargo_dt"] = unembargo_dt
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if reported_dt is not UNSET:
+        if isinstance(reported_dt, Unset):
             field_dict["reported_dt"] = reported_dt
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if nvd_cvss2 is not UNSET:
+        if isinstance(nvd_cvss2, Unset):
             field_dict["nvd_cvss2"] = nvd_cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if nvd_cvss3 is not UNSET:
+        if isinstance(nvd_cvss3, Unset):
             field_dict["nvd_cvss3"] = nvd_cvss3
-        if is_major_incident is not UNSET:
+        if isinstance(is_major_incident, Unset):
             field_dict["is_major_incident"] = is_major_incident
-        if major_incident_state is not UNSET:
+        if isinstance(major_incident_state, Unset):
             field_dict["major_incident_state"] = major_incident_state
-        if nist_cvss_validation is not UNSET:
+        if isinstance(nist_cvss_validation, Unset):
             field_dict["nist_cvss_validation"] = nist_cvss_validation
 
         return field_dict
@@ -613,79 +613,79 @@ class FlawPost(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if title is not UNSET:
+        if isinstance(title, Unset):
             field_dict["title"] = title
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if meta is not UNSET:
+        if isinstance(meta, Unset):
             field_dict["meta"] = meta
-        if comments is not UNSET:
+        if isinstance(comments, Unset):
             field_dict["comments"] = comments
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if package_versions is not UNSET:
+        if isinstance(package_versions, Unset):
             field_dict["package_versions"] = package_versions
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if requires_summary is not UNSET:
+        if isinstance(requires_summary, Unset):
             field_dict["requires_summary"] = requires_summary
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if cwe_id is not UNSET:
+        if isinstance(cwe_id, Unset):
             field_dict["cwe_id"] = cwe_id
-        if unembargo_dt is not UNSET:
+        if isinstance(unembargo_dt, Unset):
             field_dict["unembargo_dt"] = unembargo_dt
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if reported_dt is not UNSET:
+        if isinstance(reported_dt, Unset):
             field_dict["reported_dt"] = reported_dt
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if nvd_cvss2 is not UNSET:
+        if isinstance(nvd_cvss2, Unset):
             field_dict["nvd_cvss2"] = nvd_cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if nvd_cvss3 is not UNSET:
+        if isinstance(nvd_cvss3, Unset):
             field_dict["nvd_cvss3"] = nvd_cvss3
-        if is_major_incident is not UNSET:
+        if isinstance(is_major_incident, Unset):
             field_dict["is_major_incident"] = is_major_incident
-        if major_incident_state is not UNSET:
+        if isinstance(major_incident_state, Unset):
             field_dict["major_incident_state"] = major_incident_state
-        if nist_cvss_validation is not UNSET:
+        if isinstance(nist_cvss_validation, Unset):
             field_dict["nist_cvss_validation"] = nist_cvss_validation
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_post_classification.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_post_classification.py
@@ -25,9 +25,9 @@ class FlawPostClassification(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if workflow is not UNSET:
+        if isinstance(workflow, Unset):
             field_dict["workflow"] = workflow
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_post_meta_attr.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_post_meta_attr.py
@@ -77,65 +77,65 @@ class FlawPostMetaAttr(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if acks_not_needed is not UNSET:
+        if isinstance(acks_not_needed, Unset):
             field_dict["acks_not_needed"] = acks_not_needed
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if alias is not UNSET:
+        if isinstance(alias, Unset):
             field_dict["alias"] = alias
-        if bz_datascore is not UNSET:
+        if isinstance(bz_datascore, Unset):
             field_dict["bz_datascore"] = bz_datascore
-        if bz_id is not UNSET:
+        if isinstance(bz_id, Unset):
             field_dict["bz_id"] = bz_id
-        if checklists is not UNSET:
+        if isinstance(checklists, Unset):
             field_dict["checklists"] = checklists
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss2_vector is not UNSET:
+        if isinstance(cvss2_vector, Unset):
             field_dict["cvss2_vector"] = cvss2_vector
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_comment is not UNSET:
+        if isinstance(cvss3_comment, Unset):
             field_dict["cvss3_comment"] = cvss3_comment
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if cvss3_vector is not UNSET:
+        if isinstance(cvss3_vector, Unset):
             field_dict["cvss3_vector"] = cvss3_vector
-        if cwe is not UNSET:
+        if isinstance(cwe, Unset):
             field_dict["cwe"] = cwe
-        if depends_on is not UNSET:
+        if isinstance(depends_on, Unset):
             field_dict["depends_on"] = depends_on
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if jira_trackers is not UNSET:
+        if isinstance(jira_trackers, Unset):
             field_dict["jira_trackers"] = jira_trackers
-        if mitigate is not UNSET:
+        if isinstance(mitigate, Unset):
             field_dict["mitigate"] = mitigate
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if public is not UNSET:
+        if isinstance(public, Unset):
             field_dict["public"] = public
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if related_cves is not UNSET:
+        if isinstance(related_cves, Unset):
             field_dict["related_cves"] = related_cves
-        if reported is not UNSET:
+        if isinstance(reported, Unset):
             field_dict["reported"] = reported
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if task_owner is not UNSET:
+        if isinstance(task_owner, Unset):
             field_dict["task_owner"] = task_owner
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_reference.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference.py
@@ -45,21 +45,21 @@ class FlawReference(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if url is not UNSET:
+        if isinstance(url, Unset):
             field_dict["url"] = url
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
 
         return field_dict
@@ -98,21 +98,21 @@ class FlawReference(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if url is not UNSET:
+        if isinstance(url, Unset):
             field_dict["url"] = url
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_post.py
@@ -38,17 +38,17 @@ class FlawReferencePost(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if url is not UNSET:
+        if isinstance(url, Unset):
             field_dict["url"] = url
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
 
         return field_dict
@@ -82,17 +82,17 @@ class FlawReferencePost(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if url is not UNSET:
+        if isinstance(url, Unset):
             field_dict["url"] = url
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/flaw_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_report_data.py
@@ -34,13 +34,13 @@ class FlawReportData(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/jira_comment.py
+++ b/osidb_bindings/bindings/python_client/models/jira_comment.py
@@ -38,15 +38,15 @@ class JiraComment(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if author is not UNSET:
+        if isinstance(author, Unset):
             field_dict["author"] = author
-        if body is not UNSET:
+        if isinstance(body, Unset):
             field_dict["body"] = body
-        if created is not UNSET:
+        if isinstance(created, Unset):
             field_dict["created"] = created
-        if updated is not UNSET:
+        if isinstance(updated, Unset):
             field_dict["updated"] = updated
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/jira_issue.py
+++ b/osidb_bindings/bindings/python_client/models/jira_issue.py
@@ -28,13 +28,13 @@ class JiraIssue(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if key is not UNSET:
+        if isinstance(key, Unset):
             field_dict["key"] = key
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if fields is not UNSET:
+        if isinstance(fields, Unset):
             field_dict["fields"] = fields
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/jira_issue_fields.py
+++ b/osidb_bindings/bindings/python_client/models/jira_issue_fields.py
@@ -45,19 +45,19 @@ class JiraIssueFields(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if issuetype is not UNSET:
+        if isinstance(issuetype, Unset):
             field_dict["issuetype"] = issuetype
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if assignee is not UNSET:
+        if isinstance(assignee, Unset):
             field_dict["assignee"] = assignee
-        if reporter is not UNSET:
+        if isinstance(reporter, Unset):
             field_dict["reporter"] = reporter
-        if creator is not UNSET:
+        if isinstance(creator, Unset):
             field_dict["creator"] = creator
-        if customfield_12311140 is not UNSET:
+        if isinstance(customfield_12311140, Unset):
             field_dict["customfield_12311140"] = customfield_12311140
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/jira_issue_query_result.py
+++ b/osidb_bindings/bindings/python_client/models/jira_issue_query_result.py
@@ -30,9 +30,9 @@ class JiraIssueQueryResult(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if total is not UNSET:
+        if isinstance(total, Unset):
             field_dict["total"] = total
-        if issues is not UNSET:
+        if isinstance(issues, Unset):
             field_dict["issues"] = issues
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/jira_issue_type.py
+++ b/osidb_bindings/bindings/python_client/models/jira_issue_type.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
-from ..types import UNSET, OSIDBModel
+from ..types import UNSET, OSIDBModel, Unset
 
 T = TypeVar("T", bound="JiraIssueType")
 
@@ -21,9 +21,9 @@ class JiraIssueType(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/jira_user.py
+++ b/osidb_bindings/bindings/python_client/models/jira_user.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
-from ..types import UNSET, OSIDBModel
+from ..types import UNSET, OSIDBModel, Unset
 
 T = TypeVar("T", bound="JiraUser")
 
@@ -25,13 +25,13 @@ class JiraUser(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if key is not UNSET:
+        if isinstance(key, Unset):
             field_dict["key"] = key
-        if email_address is not UNSET:
+        if isinstance(email_address, Unset):
             field_dict["emailAddress"] = email_address
-        if display_name is not UNSET:
+        if isinstance(display_name, Unset):
             field_dict["displayName"] = display_name
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/meta.py
+++ b/osidb_bindings/bindings/python_client/models/meta.py
@@ -45,17 +45,17 @@ class Meta(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
@@ -137,49 +137,49 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if delegated_resolution is not UNSET:
+        if isinstance(delegated_resolution, Unset):
             field_dict["delegated_resolution"] = delegated_resolution
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_destroy_response_204.py
@@ -30,13 +30,13 @@ class OsidbApiV1AffectsDestroyResponse204(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_list_response_200.py
@@ -48,21 +48,21 @@ class OsidbApiV1AffectsListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
@@ -137,49 +137,49 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if delegated_resolution is not UNSET:
+        if isinstance(delegated_resolution, Unset):
             field_dict["delegated_resolution"] = delegated_resolution
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
@@ -137,49 +137,49 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if delegated_resolution is not UNSET:
+        if isinstance(delegated_resolution, Unset):
             field_dict["delegated_resolution"] = delegated_resolution
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if affectedness is not UNSET:
+        if isinstance(affectedness, Unset):
             field_dict["affectedness"] = affectedness
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
@@ -52,29 +52,29 @@ class OsidbApiV1FlawsAcknowledgmentsCreateResponse201(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_destroy_response_204.py
@@ -30,13 +30,13 @@ class OsidbApiV1FlawsAcknowledgmentsDestroyResponse204(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_list_response_200.py
@@ -48,21 +48,21 @@ class OsidbApiV1FlawsAcknowledgmentsListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
@@ -52,29 +52,29 @@ class OsidbApiV1FlawsAcknowledgmentsRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
@@ -52,29 +52,29 @@ class OsidbApiV1FlawsAcknowledgmentsUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if affiliation is not UNSET:
+        if isinstance(affiliation, Unset):
             field_dict["affiliation"] = affiliation
-        if from_upstream is not UNSET:
+        if isinstance(from_upstream, Unset):
             field_dict["from_upstream"] = from_upstream
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
@@ -59,31 +59,31 @@ class OsidbApiV1FlawsCommentsCreateResponse201(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if text is not UNSET:
+        if isinstance(text, Unset):
             field_dict["text"] = text
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if external_system_id is not UNSET:
+        if isinstance(external_system_id, Unset):
             field_dict["external_system_id"] = external_system_id
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if order is not UNSET:
+        if isinstance(order, Unset):
             field_dict["order"] = order
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_list_response_200.py
@@ -48,21 +48,21 @@ class OsidbApiV1FlawsCommentsListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
@@ -59,31 +59,31 @@ class OsidbApiV1FlawsCommentsRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if text is not UNSET:
+        if isinstance(text, Unset):
             field_dict["text"] = text
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if external_system_id is not UNSET:
+        if isinstance(external_system_id, Unset):
             field_dict["external_system_id"] = external_system_id
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if order is not UNSET:
+        if isinstance(order, Unset):
             field_dict["order"] = order
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
@@ -274,89 +274,89 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if title is not UNSET:
+        if isinstance(title, Unset):
             field_dict["title"] = title
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if meta is not UNSET:
+        if isinstance(meta, Unset):
             field_dict["meta"] = meta
-        if comments is not UNSET:
+        if isinstance(comments, Unset):
             field_dict["comments"] = comments
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if package_versions is not UNSET:
+        if isinstance(package_versions, Unset):
             field_dict["package_versions"] = package_versions
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if requires_summary is not UNSET:
+        if isinstance(requires_summary, Unset):
             field_dict["requires_summary"] = requires_summary
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if cwe_id is not UNSET:
+        if isinstance(cwe_id, Unset):
             field_dict["cwe_id"] = cwe_id
-        if unembargo_dt is not UNSET:
+        if isinstance(unembargo_dt, Unset):
             field_dict["unembargo_dt"] = unembargo_dt
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if reported_dt is not UNSET:
+        if isinstance(reported_dt, Unset):
             field_dict["reported_dt"] = reported_dt
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if nvd_cvss2 is not UNSET:
+        if isinstance(nvd_cvss2, Unset):
             field_dict["nvd_cvss2"] = nvd_cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if nvd_cvss3 is not UNSET:
+        if isinstance(nvd_cvss3, Unset):
             field_dict["nvd_cvss3"] = nvd_cvss3
-        if is_major_incident is not UNSET:
+        if isinstance(is_major_incident, Unset):
             field_dict["is_major_incident"] = is_major_incident
-        if major_incident_state is not UNSET:
+        if isinstance(major_incident_state, Unset):
             field_dict["major_incident_state"] = major_incident_state
-        if nist_cvss_validation is not UNSET:
+        if isinstance(nist_cvss_validation, Unset):
             field_dict["nist_cvss_validation"] = nist_cvss_validation
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_list_response_200.py
@@ -48,21 +48,21 @@ class OsidbApiV1FlawsListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
@@ -57,29 +57,29 @@ class OsidbApiV1FlawsReferencesCreateResponse201(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if url is not UNSET:
+        if isinstance(url, Unset):
             field_dict["url"] = url
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_destroy_response_204.py
@@ -30,13 +30,13 @@ class OsidbApiV1FlawsReferencesDestroyResponse204(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_list_response_200.py
@@ -48,21 +48,21 @@ class OsidbApiV1FlawsReferencesListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
@@ -57,29 +57,29 @@ class OsidbApiV1FlawsReferencesRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if url is not UNSET:
+        if isinstance(url, Unset):
             field_dict["url"] = url
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
@@ -57,29 +57,29 @@ class OsidbApiV1FlawsReferencesUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw is not UNSET:
+        if isinstance(flaw, Unset):
             field_dict["flaw"] = flaw
-        if url is not UNSET:
+        if isinstance(url, Unset):
             field_dict["url"] = url
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
@@ -274,89 +274,89 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if title is not UNSET:
+        if isinstance(title, Unset):
             field_dict["title"] = title
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if meta is not UNSET:
+        if isinstance(meta, Unset):
             field_dict["meta"] = meta
-        if comments is not UNSET:
+        if isinstance(comments, Unset):
             field_dict["comments"] = comments
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if package_versions is not UNSET:
+        if isinstance(package_versions, Unset):
             field_dict["package_versions"] = package_versions
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if requires_summary is not UNSET:
+        if isinstance(requires_summary, Unset):
             field_dict["requires_summary"] = requires_summary
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if cwe_id is not UNSET:
+        if isinstance(cwe_id, Unset):
             field_dict["cwe_id"] = cwe_id
-        if unembargo_dt is not UNSET:
+        if isinstance(unembargo_dt, Unset):
             field_dict["unembargo_dt"] = unembargo_dt
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if reported_dt is not UNSET:
+        if isinstance(reported_dt, Unset):
             field_dict["reported_dt"] = reported_dt
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if nvd_cvss2 is not UNSET:
+        if isinstance(nvd_cvss2, Unset):
             field_dict["nvd_cvss2"] = nvd_cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if nvd_cvss3 is not UNSET:
+        if isinstance(nvd_cvss3, Unset):
             field_dict["nvd_cvss3"] = nvd_cvss3
-        if is_major_incident is not UNSET:
+        if isinstance(is_major_incident, Unset):
             field_dict["is_major_incident"] = is_major_incident
-        if major_incident_state is not UNSET:
+        if isinstance(major_incident_state, Unset):
             field_dict["major_incident_state"] = major_incident_state
-        if nist_cvss_validation is not UNSET:
+        if isinstance(nist_cvss_validation, Unset):
             field_dict["nist_cvss_validation"] = nist_cvss_validation
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
@@ -274,89 +274,89 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if state is not UNSET:
+        if isinstance(state, Unset):
             field_dict["state"] = state
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if title is not UNSET:
+        if isinstance(title, Unset):
             field_dict["title"] = title
-        if trackers is not UNSET:
+        if isinstance(trackers, Unset):
             field_dict["trackers"] = trackers
-        if description is not UNSET:
+        if isinstance(description, Unset):
             field_dict["description"] = description
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if meta is not UNSET:
+        if isinstance(meta, Unset):
             field_dict["meta"] = meta
-        if comments is not UNSET:
+        if isinstance(comments, Unset):
             field_dict["comments"] = comments
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if package_versions is not UNSET:
+        if isinstance(package_versions, Unset):
             field_dict["package_versions"] = package_versions
-        if acknowledgments is not UNSET:
+        if isinstance(acknowledgments, Unset):
             field_dict["acknowledgments"] = acknowledgments
-        if references is not UNSET:
+        if isinstance(references, Unset):
             field_dict["references"] = references
-        if embargoed is not UNSET:
+        if isinstance(embargoed, Unset):
             field_dict["embargoed"] = embargoed
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if classification is not UNSET:
+        if isinstance(classification, Unset):
             field_dict["classification"] = classification
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if cve_id is not UNSET:
+        if isinstance(cve_id, Unset):
             field_dict["cve_id"] = cve_id
-        if impact is not UNSET:
+        if isinstance(impact, Unset):
             field_dict["impact"] = impact
-        if component is not UNSET:
+        if isinstance(component, Unset):
             field_dict["component"] = component
-        if summary is not UNSET:
+        if isinstance(summary, Unset):
             field_dict["summary"] = summary
-        if requires_summary is not UNSET:
+        if isinstance(requires_summary, Unset):
             field_dict["requires_summary"] = requires_summary
-        if statement is not UNSET:
+        if isinstance(statement, Unset):
             field_dict["statement"] = statement
-        if cwe_id is not UNSET:
+        if isinstance(cwe_id, Unset):
             field_dict["cwe_id"] = cwe_id
-        if unembargo_dt is not UNSET:
+        if isinstance(unembargo_dt, Unset):
             field_dict["unembargo_dt"] = unembargo_dt
-        if source is not UNSET:
+        if isinstance(source, Unset):
             field_dict["source"] = source
-        if reported_dt is not UNSET:
+        if isinstance(reported_dt, Unset):
             field_dict["reported_dt"] = reported_dt
-        if mitigation is not UNSET:
+        if isinstance(mitigation, Unset):
             field_dict["mitigation"] = mitigation
-        if cvss2 is not UNSET:
+        if isinstance(cvss2, Unset):
             field_dict["cvss2"] = cvss2
-        if cvss2_score is not UNSET:
+        if isinstance(cvss2_score, Unset):
             field_dict["cvss2_score"] = cvss2_score
-        if nvd_cvss2 is not UNSET:
+        if isinstance(nvd_cvss2, Unset):
             field_dict["nvd_cvss2"] = nvd_cvss2
-        if cvss3 is not UNSET:
+        if isinstance(cvss3, Unset):
             field_dict["cvss3"] = cvss3
-        if cvss3_score is not UNSET:
+        if isinstance(cvss3_score, Unset):
             field_dict["cvss3_score"] = cvss3_score
-        if nvd_cvss3 is not UNSET:
+        if isinstance(nvd_cvss3, Unset):
             field_dict["nvd_cvss3"] = nvd_cvss3
-        if is_major_incident is not UNSET:
+        if isinstance(is_major_incident, Unset):
             field_dict["is_major_incident"] = is_major_incident
-        if major_incident_state is not UNSET:
+        if isinstance(major_incident_state, Unset):
             field_dict["major_incident_state"] = major_incident_state
-        if nist_cvss_validation is not UNSET:
+        if isinstance(nist_cvss_validation, Unset):
             field_dict["nist_cvss_validation"] = nist_cvss_validation
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_manifest_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_manifest_retrieve_response_200.py
@@ -30,13 +30,13 @@ class OsidbApiV1ManifestRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_schema_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_schema_retrieve_response_200.py
@@ -30,13 +30,13 @@ class OsidbApiV1SchemaRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200.py
@@ -46,17 +46,17 @@ class OsidbApiV1StatusRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if osidb_data is not UNSET:
+        if isinstance(osidb_data, Unset):
             field_dict["osidb_data"] = osidb_data
-        if osidb_service is not UNSET:
+        if isinstance(osidb_service, Unset):
             field_dict["osidb_service"] = osidb_service
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_data.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_data.py
@@ -19,7 +19,7 @@ class OsidbApiV1StatusRetrieveResponse200OsidbData(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if flaw_count is not UNSET:
+        if isinstance(flaw_count, Unset):
             field_dict["flaw_count"] = flaw_count
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_list_response_200.py
@@ -48,21 +48,21 @@ class OsidbApiV1TrackersListResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
@@ -80,35 +80,35 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if external_system_id is not UNSET:
+        if isinstance(external_system_id, Unset):
             field_dict["external_system_id"] = external_system_id
-        if status is not UNSET:
+        if isinstance(status, Unset):
             field_dict["status"] = status
-        if errata is not UNSET:
+        if isinstance(errata, Unset):
             field_dict["errata"] = errata
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if ps_update_stream is not UNSET:
+        if isinstance(ps_update_stream, Unset):
             field_dict["ps_update_stream"] = ps_update_stream
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_healthy_retrieve_response_200.py
@@ -30,13 +30,13 @@ class OsidbHealthyRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200.py
@@ -47,21 +47,21 @@ class OsidbWhoamiRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if email is not UNSET:
+        if isinstance(email, Unset):
             field_dict["email"] = email
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if groups is not UNSET:
+        if isinstance(groups, Unset):
             field_dict["groups"] = groups
-        if profile is not UNSET:
+        if isinstance(profile, Unset):
             field_dict["profile"] = profile
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if username is not UNSET:
+        if isinstance(username, Unset):
             field_dict["username"] = username
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200_profile.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200_profile.py
@@ -21,9 +21,9 @@ class OsidbWhoamiRetrieveResponse200Profile(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if bz_user_id is not UNSET:
+        if isinstance(bz_user_id, Unset):
             field_dict["bz_user_id"] = bz_user_id
-        if jira_user_id is not UNSET:
+        if isinstance(jira_user_id, Unset):
             field_dict["jira_user_id"] = jira_user_id
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osim_api_v1_workflows_adjust_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osim_api_v1_workflows_adjust_create_response_200.py
@@ -30,13 +30,13 @@ class OsimApiV1WorkflowsAdjustCreateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osim_api_v1_workflows_retrieve_2_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osim_api_v1_workflows_retrieve_2_response_200.py
@@ -30,13 +30,13 @@ class OsimApiV1WorkflowsRetrieve2Response200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osim_api_v1_workflows_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osim_api_v1_workflows_retrieve_response_200.py
@@ -30,13 +30,13 @@ class OsimApiV1WorkflowsRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osim_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osim_healthy_retrieve_response_200.py
@@ -30,13 +30,13 @@ class OsimHealthyRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/osim_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osim_retrieve_response_200.py
@@ -30,13 +30,13 @@ class OsimRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_list.py
@@ -34,13 +34,13 @@ class PaginatedAffectList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_epss_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_epss_list.py
@@ -34,13 +34,13 @@ class PaginatedEPSSList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_exploit_only_report_data_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_exploit_only_report_data_list.py
@@ -34,13 +34,13 @@ class PaginatedExploitOnlyReportDataList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_acknowledgment_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_acknowledgment_list.py
@@ -34,13 +34,13 @@ class PaginatedFlawAcknowledgmentList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_comment_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_comment_list.py
@@ -34,13 +34,13 @@ class PaginatedFlawCommentList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_list.py
@@ -34,13 +34,13 @@ class PaginatedFlawList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_reference_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_reference_list.py
@@ -34,13 +34,13 @@ class PaginatedFlawReferenceList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_report_data_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_report_data_list.py
@@ -34,13 +34,13 @@ class PaginatedFlawReportDataList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_supported_products_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_supported_products_list.py
@@ -34,13 +34,13 @@ class PaginatedSupportedProductsList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/paginated_tracker_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_tracker_list.py
@@ -34,13 +34,13 @@ class PaginatedTrackerList(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if count is not UNSET:
+        if isinstance(count, Unset):
             field_dict["count"] = count
-        if next_ is not UNSET:
+        if isinstance(next_, Unset):
             field_dict["next"] = next_
-        if previous is not UNSET:
+        if isinstance(previous, Unset):
             field_dict["previous"] = previous
-        if results is not UNSET:
+        if isinstance(results, Unset):
             field_dict["results"] = results
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/supported_products.py
+++ b/osidb_bindings/bindings/python_client/models/supported_products.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
-from ..types import UNSET, OSIDBModel
+from ..types import UNSET, OSIDBModel, Unset
 
 T = TypeVar("T", bound="SupportedProducts")
 
@@ -19,7 +19,7 @@ class SupportedProducts(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_group_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_group_create_response_200.py
@@ -42,21 +42,21 @@ class TaskmanApiV1GroupCreateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if key is not UNSET:
+        if isinstance(key, Unset):
             field_dict["key"] = key
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if fields is not UNSET:
+        if isinstance(fields, Unset):
             field_dict["fields"] = fields
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_group_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_group_retrieve_response_200.py
@@ -44,17 +44,17 @@ class TaskmanApiV1GroupRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if total is not UNSET:
+        if isinstance(total, Unset):
             field_dict["total"] = total
-        if issues is not UNSET:
+        if isinstance(issues, Unset):
             field_dict["issues"] = issues
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_group_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_group_update_response_200.py
@@ -30,13 +30,13 @@ class TaskmanApiV1GroupUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_assignee_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_assignee_retrieve_response_200.py
@@ -44,17 +44,17 @@ class TaskmanApiV1TaskAssigneeRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if total is not UNSET:
+        if isinstance(total, Unset):
             field_dict["total"] = total
-        if issues is not UNSET:
+        if isinstance(issues, Unset):
             field_dict["issues"] = issues
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_assignee_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_assignee_update_response_200.py
@@ -30,13 +30,13 @@ class TaskmanApiV1TaskAssigneeUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_comment_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_comment_create_response_200.py
@@ -50,23 +50,23 @@ class TaskmanApiV1TaskCommentCreateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if author is not UNSET:
+        if isinstance(author, Unset):
             field_dict["author"] = author
-        if body is not UNSET:
+        if isinstance(body, Unset):
             field_dict["body"] = body
-        if created is not UNSET:
+        if isinstance(created, Unset):
             field_dict["created"] = created
-        if updated is not UNSET:
+        if isinstance(updated, Unset):
             field_dict["updated"] = updated
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_comment_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_comment_update_response_200.py
@@ -50,23 +50,23 @@ class TaskmanApiV1TaskCommentUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if author is not UNSET:
+        if isinstance(author, Unset):
             field_dict["author"] = author
-        if body is not UNSET:
+        if isinstance(body, Unset):
             field_dict["body"] = body
-        if created is not UNSET:
+        if isinstance(created, Unset):
             field_dict["created"] = created
-        if updated is not UNSET:
+        if isinstance(updated, Unset):
             field_dict["updated"] = updated
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_flaw_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_flaw_create_response_200.py
@@ -30,13 +30,13 @@ class TaskmanApiV1TaskFlawCreateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_flaw_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_flaw_retrieve_response_200.py
@@ -42,21 +42,21 @@ class TaskmanApiV1TaskFlawRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if key is not UNSET:
+        if isinstance(key, Unset):
             field_dict["key"] = key
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if fields is not UNSET:
+        if isinstance(fields, Unset):
             field_dict["fields"] = fields
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_flaw_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_flaw_update_response_200.py
@@ -30,13 +30,13 @@ class TaskmanApiV1TaskFlawUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_retrieve_response_200.py
@@ -42,21 +42,21 @@ class TaskmanApiV1TaskRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if id is not UNSET:
+        if isinstance(id, Unset):
             field_dict["id"] = id
-        if key is not UNSET:
+        if isinstance(key, Unset):
             field_dict["key"] = key
-        if name is not UNSET:
+        if isinstance(name, Unset):
             field_dict["name"] = name
-        if fields is not UNSET:
+        if isinstance(fields, Unset):
             field_dict["fields"] = fields
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_status_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_status_update_response_200.py
@@ -30,13 +30,13 @@ class TaskmanApiV1TaskStatusUpdateResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_unassigned_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_api_v1_task_unassigned_retrieve_response_200.py
@@ -44,17 +44,17 @@ class TaskmanApiV1TaskUnassignedRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if total is not UNSET:
+        if isinstance(total, Unset):
             field_dict["total"] = total
-        if issues is not UNSET:
+        if isinstance(issues, Unset):
             field_dict["issues"] = issues
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/taskman_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/taskman_healthy_retrieve_response_200.py
@@ -30,13 +30,13 @@ class TaskmanHealthyRetrieveResponse200(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if dt is not UNSET:
+        if isinstance(dt, Unset):
             field_dict["dt"] = dt
-        if env is not UNSET:
+        if isinstance(env, Unset):
             field_dict["env"] = env
-        if revision is not UNSET:
+        if isinstance(revision, Unset):
             field_dict["revision"] = revision
-        if version is not UNSET:
+        if isinstance(version, Unset):
             field_dict["version"] = version
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/token_obtain_pair.py
+++ b/osidb_bindings/bindings/python_client/models/token_obtain_pair.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
-from ..types import UNSET, OSIDBModel
+from ..types import UNSET, OSIDBModel, Unset
 
 T = TypeVar("T", bound="TokenObtainPair")
 
@@ -25,13 +25,13 @@ class TokenObtainPair(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if username is not UNSET:
+        if isinstance(username, Unset):
             field_dict["username"] = username
-        if password is not UNSET:
+        if isinstance(password, Unset):
             field_dict["password"] = password
-        if access is not UNSET:
+        if isinstance(access, Unset):
             field_dict["access"] = access
-        if refresh is not UNSET:
+        if isinstance(refresh, Unset):
             field_dict["refresh"] = refresh
 
         return field_dict
@@ -65,13 +65,13 @@ class TokenObtainPair(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if username is not UNSET:
+        if isinstance(username, Unset):
             field_dict["username"] = username
-        if password is not UNSET:
+        if isinstance(password, Unset):
             field_dict["password"] = password
-        if access is not UNSET:
+        if isinstance(access, Unset):
             field_dict["access"] = access
-        if refresh is not UNSET:
+        if isinstance(refresh, Unset):
             field_dict["refresh"] = refresh
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/token_refresh.py
+++ b/osidb_bindings/bindings/python_client/models/token_refresh.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
-from ..types import UNSET, OSIDBModel
+from ..types import UNSET, OSIDBModel, Unset
 
 T = TypeVar("T", bound="TokenRefresh")
 
@@ -21,9 +21,9 @@ class TokenRefresh(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if access is not UNSET:
+        if isinstance(access, Unset):
             field_dict["access"] = access
-        if refresh is not UNSET:
+        if isinstance(refresh, Unset):
             field_dict["refresh"] = refresh
 
         return field_dict
@@ -47,9 +47,9 @@ class TokenRefresh(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if access is not UNSET:
+        if isinstance(access, Unset):
             field_dict["access"] = access
-        if refresh is not UNSET:
+        if isinstance(refresh, Unset):
             field_dict["refresh"] = refresh
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/token_verify.py
+++ b/osidb_bindings/bindings/python_client/models/token_verify.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type, TypeVar
 
 import attr
 
-from ..types import UNSET, OSIDBModel
+from ..types import UNSET, OSIDBModel, Unset
 
 T = TypeVar("T", bound="TokenVerify")
 
@@ -19,7 +19,7 @@ class TokenVerify(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if token is not UNSET:
+        if isinstance(token, Unset):
             field_dict["token"] = token
 
         return field_dict
@@ -36,7 +36,7 @@ class TokenVerify(OSIDBModel):
                 for key, value in self.additional_properties.items()
             }
         )
-        if token is not UNSET:
+        if isinstance(token, Unset):
             field_dict["token"] = token
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/tracker.py
+++ b/osidb_bindings/bindings/python_client/models/tracker.py
@@ -69,27 +69,27 @@ class Tracker(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if uuid is not UNSET:
+        if isinstance(uuid, Unset):
             field_dict["uuid"] = uuid
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if external_system_id is not UNSET:
+        if isinstance(external_system_id, Unset):
             field_dict["external_system_id"] = external_system_id
-        if status is not UNSET:
+        if isinstance(status, Unset):
             field_dict["status"] = status
-        if errata is not UNSET:
+        if isinstance(errata, Unset):
             field_dict["errata"] = errata
-        if meta_attr is not UNSET:
+        if isinstance(meta_attr, Unset):
             field_dict["meta_attr"] = meta_attr
-        if created_dt is not UNSET:
+        if isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
-        if updated_dt is not UNSET:
+        if isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
-        if affects is not UNSET:
+        if isinstance(affects, Unset):
             field_dict["affects"] = affects
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if ps_update_stream is not UNSET:
+        if isinstance(ps_update_stream, Unset):
             field_dict["ps_update_stream"] = ps_update_stream
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/tracker_meta_attr.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_meta_attr.py
@@ -33,21 +33,21 @@ class TrackerMetaAttr(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if bz_id is not UNSET:
+        if isinstance(bz_id, Unset):
             field_dict["bz_id"] = bz_id
-        if owner is not UNSET:
+        if isinstance(owner, Unset):
             field_dict["owner"] = owner
-        if qe_owner is not UNSET:
+        if isinstance(qe_owner, Unset):
             field_dict["qe_owner"] = qe_owner
-        if ps_component is not UNSET:
+        if isinstance(ps_component, Unset):
             field_dict["ps_component"] = ps_component
-        if ps_module is not UNSET:
+        if isinstance(ps_module, Unset):
             field_dict["ps_module"] = ps_module
-        if ps_update_stream is not UNSET:
+        if isinstance(ps_update_stream, Unset):
             field_dict["ps_update_stream"] = ps_update_stream
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
-        if status is not UNSET:
+        if isinstance(status, Unset):
             field_dict["status"] = status
 
         return field_dict

--- a/osidb_bindings/bindings/python_client/models/tracker_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_report_data.py
@@ -30,13 +30,13 @@ class TrackerReportData(OSIDBModel):
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        if type is not UNSET:
+        if isinstance(type, Unset):
             field_dict["type"] = type
-        if external_system_id is not UNSET:
+        if isinstance(external_system_id, Unset):
             field_dict["external_system_id"] = external_system_id
-        if status is not UNSET:
+        if isinstance(status, Unset):
             field_dict["status"] = status
-        if resolution is not UNSET:
+        if isinstance(resolution, Unset):
             field_dict["resolution"] = resolution
 
         return field_dict

--- a/osidb_bindings/templates/model.py.jinja
+++ b/osidb_bindings/templates/model.py.jinja
@@ -2,7 +2,7 @@
     This is a custom template derived from:
     https://github.com/openapi-generators/openapi-python-client/blob/v.0.10.7/openapi_python_client/templates/model.py.jinja
 #}
-from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, Union
 
 {% if model.additional_properties %}
 from typing import List
@@ -75,7 +75,7 @@ field_dict.update(self.additional_properties)
 {% endif %}
 {% endif %}
 {% for property in  model.required_properties + model.optional_properties %}
-if {{ property.python_name }} is not UNSET:
+if isinstance({{ property.python_name }}, Unset):
     field_dict["{{ property.name }}"] = {{ property.python_name }}
 {% endfor %}
 


### PR DESCRIPTION
In some cases (mainly when using multiprocessing) it occurred that were multiple instances of Unset and since the to_dict method was checking for direct equality, it broke the transformation as it kept the Unset values. This PR changes the direct equality check for isinstance check so bindings models from different processes and from different sessions may be used together.