### PR TITLE
Workaround Erratum shipped_dt nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- add workaround for Erratum shipped_dt which is marked as non-nullable
+  despite being nullable
 
 ## [3.5.0] - 2023-10-12
 ### Added

--- a/osidb_bindings/bindings/python_client/models/erratum.py
+++ b/osidb_bindings/bindings/python_client/models/erratum.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 import attr
 from dateutil.parser import isoparse
@@ -15,18 +15,14 @@ class Erratum(OSIDBModel):
 
     et_id: int
     advisory_name: str
-    shipped_dt: datetime.datetime
     created_dt: datetime.datetime
     updated_dt: datetime.datetime
+    shipped_dt: Optional[datetime.datetime]
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         et_id = self.et_id
         advisory_name = self.advisory_name
-        shipped_dt: str = UNSET
-        if not isinstance(self.shipped_dt, Unset):
-            shipped_dt = self.shipped_dt.isoformat()
-
         created_dt: str = UNSET
         if not isinstance(self.created_dt, Unset):
             created_dt = self.created_dt.isoformat()
@@ -35,18 +31,22 @@ class Erratum(OSIDBModel):
         if not isinstance(self.updated_dt, Unset):
             updated_dt = self.updated_dt.isoformat()
 
+        shipped_dt: Optional[str] = UNSET
+        if not isinstance(self.shipped_dt, Unset):
+            shipped_dt = self.shipped_dt.isoformat() if self.shipped_dt else None
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         if not isinstance(et_id, Unset):
             field_dict["et_id"] = et_id
         if not isinstance(advisory_name, Unset):
             field_dict["advisory_name"] = advisory_name
-        if not isinstance(shipped_dt, Unset):
-            field_dict["shipped_dt"] = shipped_dt
         if not isinstance(created_dt, Unset):
             field_dict["created_dt"] = created_dt
         if not isinstance(updated_dt, Unset):
             field_dict["updated_dt"] = updated_dt
+        if not isinstance(shipped_dt, Unset):
+            field_dict["shipped_dt"] = shipped_dt
 
         return field_dict
 
@@ -56,13 +56,6 @@ class Erratum(OSIDBModel):
         et_id = d.pop("et_id", UNSET)
 
         advisory_name = d.pop("advisory_name", UNSET)
-
-        _shipped_dt = d.pop("shipped_dt", UNSET)
-        shipped_dt: datetime.datetime
-        if isinstance(_shipped_dt, Unset):
-            shipped_dt = UNSET
-        else:
-            shipped_dt = isoparse(_shipped_dt)
 
         _created_dt = d.pop("created_dt", UNSET)
         created_dt: datetime.datetime
@@ -78,12 +71,21 @@ class Erratum(OSIDBModel):
         else:
             updated_dt = isoparse(_updated_dt)
 
+        _shipped_dt = d.pop("shipped_dt", UNSET)
+        shipped_dt: Optional[datetime.datetime]
+        if _shipped_dt is None:
+            shipped_dt = None
+        elif isinstance(_shipped_dt, Unset):
+            shipped_dt = UNSET
+        else:
+            shipped_dt = isoparse(_shipped_dt)
+
         erratum = cls(
             et_id=et_id,
             advisory_name=advisory_name,
-            shipped_dt=shipped_dt,
             created_dt=created_dt,
             updated_dt=updated_dt,
+            shipped_dt=shipped_dt,
         )
 
         erratum.additional_properties = d
@@ -94,9 +96,9 @@ class Erratum(OSIDBModel):
         return {
             "et_id": int,
             "advisory_name": str,
-            "shipped_dt": datetime.datetime,
             "created_dt": datetime.datetime,
             "updated_dt": datetime.datetime,
+            "shipped_dt": datetime.datetime,
         }
 
     @property

--- a/osidb_bindings/openapi_schema.yml
+++ b/osidb_bindings/openapi_schema.yml
@@ -7637,6 +7637,7 @@ components:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
         created_dt:
           type: string
           format: date-time


### PR DESCRIPTION
Erratum `shipped_dt` is nullable in the OSIDB database however in the schema it is marked as non-nullable field and thus bindings are failing to parse Erratums with null `shipped_dt`.

This is being properly addressed on the OSIDB part as per https://github.com/RedHatProductSecurity/osidb/pull/355, however for the time being, we are going to fix it on the bindings side.