### PR TITLE
Build copr rpm

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,9 @@
+srpm:
+	@echo ">Installing SRPM dependencies"
+	dnf install -y python3-setuptools rpmdevtools
+
+	@echo ">Setting up rpm build environment"
+	rpmdev-setuptree -d
+
+	@echo ">Building SRPM"
+	scripts/build_srpm.sh $(outdir)

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -280,3 +280,7 @@ When new major/minor OSIDB version is being released, we can do a pre-release of
     * Tag and release needs be in format x.x.x to comply with [semantic versioning](#version-policy)
     * Tag needs to point to the latest commit
     * Release description should include the newest section of the [CHANGELOG.md](CHANGELOG.md)
+
+### Fedora COPR RPM build
+
+There is an RPM repository setup in [Fedora COPR](https://copr.fedorainfracloud.org/coprs/jazinner/osidb-bindings/). RPMs are build automatically based on git tag events. When a git tag is added to the repository Fedora COPR runs the .copr/Makefile which builds an RPM for the target distributions (currently Fedora 39 and 40).

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -15,6 +15,12 @@ You can install the bindings via Python 3 pip:
     ```
     pip install osidb-bindings
     ```
+* RPM from [Fedora Copr](https://copr.fedorainfracloud.org/coprs/jazinner/osidb-bindings/)
+    ```
+    dnf copr enable jazinner/osidb-bindings
+    dnf install osidb_bindings
+    ```
+
 * directly from the [GitHub](https://github.com/RedHatProductSecurity/osidb-bindings) repository (will install the version
     from master branch)
     ```

--- a/osidb_bindings.spec
+++ b/osidb_bindings.spec
@@ -1,0 +1,58 @@
+%define name osidb_bindings
+%define version 3.7.0
+%define release 0%{?dist}
+
+Name:           %{name}
+Version:        %{version}
+Release:        %{release}
+Summary:        OSIDB Python Bindings
+
+URL:            https://github.com/RedHatProductSecurity/osdib-bindings
+Source0:        %{name}-%{version}.tar.gz
+License: MIT
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+
+BuildArch:      noarch
+AutoReqProv: no
+BuildRequires:  python3-devel
+BuildRequires:  python3-wheel
+BuildRequires:  tox
+BuildRequires:  python3-tox-current-env
+Requires:       python3-aiohttp
+Requires:       python3-attrs
+Requires:       python3-dateutil
+Requires:       python3-requests
+Requires:       python3-requests-gssapi
+
+
+%description
+Python Client bindings for OSIDB
+
+%prep
+%autosetup -n %{name}-%{version} -p1
+
+%generate_buildrequires
+
+%pyproject_buildrequires
+
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+
+%pyproject_save_files %{name}
+
+%check
+%tox
+
+%files -n %{name} -f %{pyproject_files}
+%ghost %{python3_sitelib}/tests/*
+
+%changelog
+* Wed May 22 2024 Jason <jshepher@redhat.com> - 3.6.0
+- RPM packing for osidb_bindings added
+
+
+

--- a/osidb_bindings/helpers.py
+++ b/osidb_bindings/helpers.py
@@ -2,11 +2,32 @@
 osidb-registry-bindings helpers
 """
 import json
-from distutils.util import strtobool
 from os import getenv
 from typing import Any, Union
 
 from .exceptions import OSIDBBindingsException
+
+_MAP = {
+    "y": True,
+    "yes": True,
+    "t": True,
+    "true": True,
+    "on": True,
+    "1": True,
+    "n": False,
+    "no": False,
+    "f": False,
+    "false": False,
+    "off": False,
+    "0": False,
+}
+
+
+def strtobool(value):
+    try:
+        return _MAP[str(value).lower()]
+    except KeyError:
+        raise ValueError('"{}" is not a valid bool value'.format(value))
 
 
 def get_env(

--- a/scripts/build_srpm.sh
+++ b/scripts/build_srpm.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+mkdir dist
+python3 setup.py clean sdist
+cp dist/* ~/build/SOURCES/
+rpmbuild --undefine dist -bs "osidb_bindings.spec" --clean
+cp ~/build/SRPMS/* "$1"
+

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -56,6 +56,9 @@ update_version() {
     echo "Updating the CHANGELOG.md to ${version}"
     sed -i 's/^## Unreleased.*/## Unreleased\n\n## ['"${version}"'] - '$(date '+%Y-%m-%d')'/' CHANGELOG.md
 
+    echo "Updating the osidb_bindings.spec to ${version}"
+    sed -i 's/^%define version [0-9]*\.[0-9]*\.[0-9]*/%define version '${version}'/g' osidb_bindings.spec
+
     echo
 }
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="osidb-bindings",
+    name="osidb_bindings",
     version="3.7.0",
     author="Jakub Frejlach, Red Hat Product Security",
     author_email="jfrejlac@redhat.com",


### PR DESCRIPTION
This is working for Fedora 38-40 builds now, see https://copr.fedorainfracloud.org/coprs/jazinner/osidb-bindings/build/7494516/

However I had to adjust the project name in setup.py from osidb-bindings to osidb_bindings. I guess that will have an impact on the existing Pypi package. 

@JakubFrejlach @JimFuller-RedHat please review.