### PR TITLE
Use application/json instead of multipart/form-data format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- request format changed from form-data to json which
+  prevents OSIDB serialization failures (OSIDB-2844)
 
 ## [3.7.0] - 2024-05-23
 ### Added

--- a/osidb_bindings/bindings/python_client/api/auth/auth_token_create.py
+++ b/osidb_bindings/bindings/python_client/api/auth/auth_token_create.py
@@ -35,7 +35,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/auth/auth_token_refresh_create.py
+++ b/osidb_bindings/bindings/python_client/api/auth/auth_token_refresh_create.py
@@ -37,7 +37,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/auth/auth_token_verify_create.py
+++ b/osidb_bindings/bindings/python_client/api/auth/auth_token_verify_create.py
@@ -37,7 +37,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_create.py
@@ -37,7 +37,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_cvss_scores_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_cvss_scores_create.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_cvss_scores_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_cvss_scores_update.py
@@ -41,7 +41,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_affects_update.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_acknowledgments_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_acknowledgments_create.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_acknowledgments_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_acknowledgments_update.py
@@ -41,7 +41,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_comments_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_comments_create.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_create.py
@@ -37,7 +37,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_cvss_scores_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_cvss_scores_create.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_cvss_scores_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_cvss_scores_update.py
@@ -41,7 +41,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_package_versions_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_package_versions_create.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_package_versions_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_package_versions_update.py
@@ -41,7 +41,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_references_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_references_create.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_references_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_references_update.py
@@ -41,7 +41,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_reject_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_reject_create.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_flaws_update.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_trackers_create.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_trackers_create.py
@@ -37,7 +37,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_trackers_update.py
+++ b/osidb_bindings/bindings/python_client/api/osidb/osidb_api_v1_trackers_update.py
@@ -39,7 +39,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/bindings/python_client/api/trackers/trackers_api_v1_file_create.py
+++ b/osidb_bindings/bindings/python_client/api/trackers/trackers_api_v1_file_create.py
@@ -35,7 +35,7 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        "data": form_data.to_dict(),
+        "json": form_data.to_dict(),
     }
 
 

--- a/osidb_bindings/templates/endpoint_module.py.jinja
+++ b/osidb_bindings/templates/endpoint_module.py.jinja
@@ -51,12 +51,19 @@ def _get_kwargs(
     return {
         "url": url,
         "headers": headers,
-        {% if endpoint.form_body_class %}
+        {# {% if endpoint.form_body_class %}
         "data": form_data.to_dict(),
         {% elif endpoint.multipart_body %}
         "files": {{ "multipart_" + endpoint.multipart_body.python_name }},
         {% elif endpoint.json_body %}
         "json": {{ "json_" + endpoint.json_body.python_name }},
+        {% endif %} #}
+        {% if endpoint.json_body %}
+        "json": form_data.to_dict(),
+        {% elif endpoint.form_body_class %}
+        "data": form_data.to_dict(),
+        {% elif endpoint.multipart_body %}
+        "files": {{ "multipart_" + endpoint.multipart_body.python_name }},
         {% endif %}
         {% if endpoint.query_parameters %}
         "params": params,


### PR DESCRIPTION
This PR:
* changes osidb-bindings requests data format to preferably use application/json as multipart/form-data is causing serialization issues on the OSIDB side (in the future OSIDB will restrict using the application/json exclusively to avoid discrepancies between different API users/OSIM/etc.)

Closes OSIDB-2844