### PR TITLE
Fix COPR release

### DIFF
--- a/osidb_bindings.spec
+++ b/osidb_bindings.spec
@@ -1,5 +1,5 @@
 %define name osidb_bindings
-%define version 4.1.0
+%define version 4.1.1
 %define release 0%{?dist}
 
 Name:           %{name}

--- a/scripts/patch_release.sh
+++ b/scripts/patch_release.sh
@@ -16,7 +16,7 @@ commit() {
 
     echo "Committing changes"
 
-    git add setup.py CHANGELOG.md osidb_bindings/bindings/pyproject.toml osidb_bindings/constants.py
+    git add setup.py CHANGELOG.md osidb_bindings/bindings/pyproject.toml osidb_bindings/constants.py osidb_bindings.spec
     git commit -m "Preparation of ${version} release"
     echo
 }


### PR DESCRIPTION
COPR release is quite a new thing and apparently patch release script (`make patch-release`) wasn't accounting for updating the `osidb_bindings.spec` with the new version.

For major/minor release and pre-release this has been already fixed.