### PR TITLE
OSIDB-3201: Expose workflow operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- support for `promote` operation for `flaw` (OSIDB-3201)
 
 ## [4.1.1] - 2024-07-10
 ### Added

--- a/osidb_bindings/session.py
+++ b/osidb_bindings/session.py
@@ -59,7 +59,7 @@ def file_trackers(self, form_data: Dict[str, Any], *args, **kwargs):
             f'and the operation "file" is not defined.'
         )
 
-    transformed_data = model.from_dict(form_data)
+    transformed_data = serialize_data(form_data, model)
     sync_fn = get_sync_function(method_module)
     return sync_fn(
         *args,
@@ -97,7 +97,7 @@ def reject_flaw(self, id: str, form_data: Dict[str, Any], *args, **kwargs):
             f'The request body for the resource "flaw" '
             f'and the operation "reject" is not defined.'
         )
-    transformed_data = model.from_dict(form_data)
+    transformed_data = serialize_data(form_data, model)
     return sync_fn(
         id,
         *args,

--- a/osidb_bindings/session.py
+++ b/osidb_bindings/session.py
@@ -71,6 +71,44 @@ def file_trackers(self, form_data: Dict[str, Any], *args, **kwargs):
     )
 
 
+def promote_flaw(self, id, *args, **kwargs):
+    method_module = importlib.import_module(
+        f".bindings.python_client.api.osidb.osidb_api_{OSIDB_API_VERSION}_flaws_promote_create",
+        package="osidb_bindings",
+    )
+    sync_fn = get_sync_function(method_module)
+    return sync_fn(
+        id,
+        *args,
+        client=self.client(),
+        **kwargs,
+    )
+
+
+def reject_flaw(self, id: str, form_data: Dict[str, Any], *args, **kwargs):
+    method_module = importlib.import_module(
+        f".bindings.python_client.api.osidb.osidb_api_{OSIDB_API_VERSION}_flaws_reject_create",
+        package="osidb_bindings",
+    )
+    sync_fn = get_sync_function(method_module)
+    model = getattr(method_module, "REQUEST_BODY_TYPE", None)
+    if model is None:
+        raise UndefinedRequestBody(
+            f'The request body for the resource "flaw" '
+            f'and the operation "reject" is not defined.'
+        )
+    transformed_data = model.from_dict(form_data)
+    return sync_fn(
+        id,
+        *args,
+        client=self.client(),
+        form_data=transformed_data,
+        multipart_data=UNSET,
+        json_body=UNSET,
+        **kwargs,
+    )
+
+
 def double_underscores_to_single_underscores(fn):
     """
     Function decorator which changes all the keyword arguments which include
@@ -214,6 +252,7 @@ class Session:
                     ]
                 },
             },
+            extra_operations=[("promote", promote_flaw), ("reject", reject_flaw)],
         )
         self.affects = SessionOperationsGroup(
             self.__get_client_with_new_access_token,


### PR DESCRIPTION
New methods added:

* [`promote_flaw`](diffhunk://#diff-9fd614fe79818d515f3f04a9681066faadb4bb7792340630642c6c0256af4486R74-R101): Added to promote a flaw using the appropriate API endpoint and client.
* [`reject_flaw`](diffhunk://#diff-9fd614fe79818d515f3f04a9681066faadb4bb7792340630642c6c0256af4486R74-R101): Added to reject a flaw using the appropriate API endpoint and client.

Integration with session operations:

* `__init__` method: Updated to include `promote_flaw` and `reject_flaw` in the `extra_operations` parameter, integrating these new methods into the session operations.

Closes OSIDB-3201