### PR TITLE
Fix UUID handling

### DIFF
--- a/osidb_bindings/bindings/python_client/models/affect.py
+++ b/osidb_bindings/bindings/python_client/models/affect.py
@@ -407,7 +407,7 @@ class Affect(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
@@ -421,7 +421,11 @@ class Affect(OSIDBModel):
                 if isinstance(_flaw_type_0, Unset):
                     flaw_type_0 = UNSET
                 else:
-                    flaw_type_0 = UUID(_flaw_type_0)
+                    flaw_type_0 = (
+                        _flaw_type_0
+                        if isinstance(_flaw_type_0, UUID)
+                        else UUID(_flaw_type_0)
+                    )
 
                 return flaw_type_0
             except:  # noqa: E722

--- a/osidb_bindings/bindings/python_client/models/affect_bulk_put.py
+++ b/osidb_bindings/bindings/python_client/models/affect_bulk_put.py
@@ -225,7 +225,7 @@ class AffectBulkPut(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
@@ -239,7 +239,11 @@ class AffectBulkPut(OSIDBModel):
                 if isinstance(_flaw_type_0, Unset):
                     flaw_type_0 = UNSET
                 else:
-                    flaw_type_0 = UUID(_flaw_type_0)
+                    flaw_type_0 = (
+                        _flaw_type_0
+                        if isinstance(_flaw_type_0, UUID)
+                        else UUID(_flaw_type_0)
+                    )
 
                 return flaw_type_0
             except:  # noqa: E722

--- a/osidb_bindings/bindings/python_client/models/affect_cvss.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss.py
@@ -153,7 +153,7 @@ class AffectCVSS(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -194,7 +194,7 @@ class AffectCVSS(OSIDBModel):
         if isinstance(_affect, Unset):
             affect = UNSET
         else:
-            affect = UUID(_affect)
+            affect = _affect if isinstance(_affect, UUID) else UUID(_affect)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/affect_cvss_post.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss_post.py
@@ -207,7 +207,7 @@ class AffectCVSSPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/affect_cvss_put.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss_put.py
@@ -222,7 +222,7 @@ class AffectCVSSPut(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/affect_post.py
+++ b/osidb_bindings/bindings/python_client/models/affect_post.py
@@ -392,7 +392,7 @@ class AffectPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
@@ -406,7 +406,11 @@ class AffectPost(OSIDBModel):
                 if isinstance(_flaw_type_0, Unset):
                     flaw_type_0 = UNSET
                 else:
-                    flaw_type_0 = UUID(_flaw_type_0)
+                    flaw_type_0 = (
+                        _flaw_type_0
+                        if isinstance(_flaw_type_0, UUID)
+                        else UUID(_flaw_type_0)
+                    )
 
                 return flaw_type_0
             except:  # noqa: E722

--- a/osidb_bindings/bindings/python_client/models/alert.py
+++ b/osidb_bindings/bindings/python_client/models/alert.py
@@ -82,7 +82,7 @@ class Alert(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         name = d.pop("name", UNSET)
 
@@ -94,7 +94,9 @@ class Alert(OSIDBModel):
         if isinstance(_parent_uuid, Unset):
             parent_uuid = UNSET
         else:
-            parent_uuid = UUID(_parent_uuid)
+            parent_uuid = (
+                _parent_uuid if isinstance(_parent_uuid, UUID) else UUID(_parent_uuid)
+            )
 
         parent_model = d.pop("parent_model", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/comment.py
+++ b/osidb_bindings/bindings/python_client/models/comment.py
@@ -114,7 +114,7 @@ class Comment(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         text = d.pop("text", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw.py
+++ b/osidb_bindings/bindings/python_client/models/flaw.py
@@ -828,7 +828,7 @@ class Flaw(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         title = d.pop("title", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
@@ -119,7 +119,7 @@ class FlawAcknowledgment(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -127,7 +127,7 @@ class FlawAcknowledgment(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post.py
@@ -152,7 +152,7 @@ class FlawAcknowledgmentPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put.py
@@ -167,7 +167,7 @@ class FlawAcknowledgmentPut(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_comment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment.py
@@ -125,7 +125,7 @@ class FlawComment(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         text = d.pop("text", UNSET)
 
@@ -135,7 +135,7 @@ class FlawComment(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         external_system_id = d.pop("external_system_id", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_comment_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment_post.py
@@ -156,7 +156,7 @@ class FlawCommentPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         alerts = []
         _alerts = d.pop("alerts", UNSET)

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss.py
@@ -153,7 +153,7 @@ class FlawCVSS(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -194,7 +194,7 @@ class FlawCVSS(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_post.py
@@ -207,7 +207,7 @@ class FlawCVSSPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_put.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_put.py
@@ -222,7 +222,7 @@ class FlawCVSSPut(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version.py
@@ -116,7 +116,7 @@ class FlawPackageVersion(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -124,7 +124,7 @@ class FlawPackageVersion(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version_post.py
@@ -141,7 +141,7 @@ class FlawPackageVersionPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version_put.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version_put.py
@@ -156,7 +156,7 @@ class FlawPackageVersionPut(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_post.py
@@ -813,7 +813,7 @@ class FlawPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         title = d.pop("title", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_reference.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference.py
@@ -116,7 +116,7 @@ class FlawReference(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         url = d.pop("url", UNSET)
 
@@ -126,7 +126,7 @@ class FlawReference(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_post.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_post.py
@@ -158,7 +158,7 @@ class FlawReferencePost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_put.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_put.py
@@ -173,7 +173,7 @@ class FlawReferencePut(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/flaw_uuid_list.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_uuid_list.py
@@ -75,7 +75,11 @@ class FlawUUIDList(OSIDBModel):
             if isinstance(_flaw_uuids_item, Unset):
                 flaw_uuids_item = UNSET
             else:
-                flaw_uuids_item = UUID(_flaw_uuids_item)
+                flaw_uuids_item = (
+                    _flaw_uuids_item
+                    if isinstance(_flaw_uuids_item, UUID)
+                    else UUID(_flaw_uuids_item)
+                )
 
             flaw_uuids.append(flaw_uuids_item)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
@@ -250,7 +250,7 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
@@ -264,7 +264,11 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
                 if isinstance(_flaw_type_0, Unset):
                     flaw_type_0 = UNSET
                 else:
-                    flaw_type_0 = UUID(_flaw_type_0)
+                    flaw_type_0 = (
+                        _flaw_type_0
+                        if isinstance(_flaw_type_0, UUID)
+                        else UUID(_flaw_type_0)
+                    )
 
                 return flaw_type_0
             except:  # noqa: E722

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_create_response_201.py
@@ -178,7 +178,7 @@ class OsidbApiV1AffectsCvssScoresCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -219,7 +219,7 @@ class OsidbApiV1AffectsCvssScoresCreateResponse201(OSIDBModel):
         if isinstance(_affect, Unset):
             affect = UNSET
         else:
-            affect = UUID(_affect)
+            affect = _affect if isinstance(_affect, UUID) else UUID(_affect)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_retrieve_response_200.py
@@ -178,7 +178,7 @@ class OsidbApiV1AffectsCvssScoresRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -219,7 +219,7 @@ class OsidbApiV1AffectsCvssScoresRetrieveResponse200(OSIDBModel):
         if isinstance(_affect, Unset):
             affect = UNSET
         else:
-            affect = UUID(_affect)
+            affect = _affect if isinstance(_affect, UUID) else UUID(_affect)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_update_response_200.py
@@ -178,7 +178,7 @@ class OsidbApiV1AffectsCvssScoresUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -219,7 +219,7 @@ class OsidbApiV1AffectsCvssScoresUpdateResponse200(OSIDBModel):
         if isinstance(_affect, Unset):
             affect = UNSET
         else:
-            affect = UUID(_affect)
+            affect = _affect if isinstance(_affect, UUID) else UUID(_affect)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
@@ -250,7 +250,7 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
@@ -264,7 +264,11 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
                 if isinstance(_flaw_type_0, Unset):
                     flaw_type_0 = UNSET
                 else:
-                    flaw_type_0 = UUID(_flaw_type_0)
+                    flaw_type_0 = (
+                        _flaw_type_0
+                        if isinstance(_flaw_type_0, UUID)
+                        else UUID(_flaw_type_0)
+                    )
 
                 return flaw_type_0
             except:  # noqa: E722

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
@@ -250,7 +250,7 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
@@ -264,7 +264,11 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
                 if isinstance(_flaw_type_0, Unset):
                     flaw_type_0 = UNSET
                 else:
-                    flaw_type_0 = UUID(_flaw_type_0)
+                    flaw_type_0 = (
+                        _flaw_type_0
+                        if isinstance(_flaw_type_0, UUID)
+                        else UUID(_flaw_type_0)
+                    )
 
                 return flaw_type_0
             except:  # noqa: E722

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_retrieve_response_200.py
@@ -109,7 +109,7 @@ class OsidbApiV1AlertsRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         name = d.pop("name", UNSET)
 
@@ -121,7 +121,9 @@ class OsidbApiV1AlertsRetrieveResponse200(OSIDBModel):
         if isinstance(_parent_uuid, Unset):
             parent_uuid = UNSET
         else:
-            parent_uuid = UUID(_parent_uuid)
+            parent_uuid = (
+                _parent_uuid if isinstance(_parent_uuid, UUID) else UUID(_parent_uuid)
+            )
 
         parent_model = d.pop("parent_model", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
@@ -144,7 +144,7 @@ class OsidbApiV1FlawsAcknowledgmentsCreateResponse201(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -152,7 +152,7 @@ class OsidbApiV1FlawsAcknowledgmentsCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
@@ -144,7 +144,7 @@ class OsidbApiV1FlawsAcknowledgmentsRetrieveResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -152,7 +152,7 @@ class OsidbApiV1FlawsAcknowledgmentsRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
@@ -144,7 +144,7 @@ class OsidbApiV1FlawsAcknowledgmentsUpdateResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -152,7 +152,7 @@ class OsidbApiV1FlawsAcknowledgmentsUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
@@ -150,7 +150,7 @@ class OsidbApiV1FlawsCommentsCreateResponse201(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         text = d.pop("text", UNSET)
 
@@ -160,7 +160,7 @@ class OsidbApiV1FlawsCommentsCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         external_system_id = d.pop("external_system_id", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
@@ -150,7 +150,7 @@ class OsidbApiV1FlawsCommentsRetrieveResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         text = d.pop("text", UNSET)
 
@@ -160,7 +160,7 @@ class OsidbApiV1FlawsCommentsRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         external_system_id = d.pop("external_system_id", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
@@ -450,7 +450,7 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         title = d.pop("title", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_create_response_201.py
@@ -178,7 +178,7 @@ class OsidbApiV1FlawsCvssScoresCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -219,7 +219,7 @@ class OsidbApiV1FlawsCvssScoresCreateResponse201(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_retrieve_response_200.py
@@ -178,7 +178,7 @@ class OsidbApiV1FlawsCvssScoresRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -219,7 +219,7 @@ class OsidbApiV1FlawsCvssScoresRetrieveResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_update_response_200.py
@@ -178,7 +178,7 @@ class OsidbApiV1FlawsCvssScoresUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         vector = d.pop("vector", UNSET)
 
@@ -219,7 +219,7 @@ class OsidbApiV1FlawsCvssScoresUpdateResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         def _parse_comment(data: object) -> Union[None, Unset, str]:
             if data is None:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_create_response_201.py
@@ -141,7 +141,7 @@ class OsidbApiV1FlawsPackageVersionsCreateResponse201(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -149,7 +149,7 @@ class OsidbApiV1FlawsPackageVersionsCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_retrieve_response_200.py
@@ -141,7 +141,7 @@ class OsidbApiV1FlawsPackageVersionsRetrieveResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -149,7 +149,7 @@ class OsidbApiV1FlawsPackageVersionsRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_update_response_200.py
@@ -141,7 +141,7 @@ class OsidbApiV1FlawsPackageVersionsUpdateResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         # }
         _uuid = d.pop("uuid", UNSET)
@@ -149,7 +149,7 @@ class OsidbApiV1FlawsPackageVersionsUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
@@ -141,7 +141,7 @@ class OsidbApiV1FlawsReferencesCreateResponse201(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         url = d.pop("url", UNSET)
 
@@ -151,7 +151,7 @@ class OsidbApiV1FlawsReferencesCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
@@ -141,7 +141,7 @@ class OsidbApiV1FlawsReferencesRetrieveResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         url = d.pop("url", UNSET)
 
@@ -151,7 +151,7 @@ class OsidbApiV1FlawsReferencesRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
@@ -141,7 +141,7 @@ class OsidbApiV1FlawsReferencesUpdateResponse200(OSIDBModel):
         if isinstance(_flaw, Unset):
             flaw = UNSET
         else:
-            flaw = UUID(_flaw)
+            flaw = _flaw if isinstance(_flaw, UUID) else UUID(_flaw)
 
         url = d.pop("url", UNSET)
 
@@ -151,7 +151,7 @@ class OsidbApiV1FlawsReferencesUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
@@ -450,7 +450,7 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         title = d.pop("title", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
@@ -450,7 +450,7 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         title = d.pop("title", UNSET)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_create_response_201.py
@@ -204,7 +204,7 @@ class OsidbApiV1TrackersCreateResponse201(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 
@@ -246,7 +246,11 @@ class OsidbApiV1TrackersCreateResponse201(OSIDBModel):
             if isinstance(_affects_item, Unset):
                 affects_item = UNSET
             else:
-                affects_item = UUID(_affects_item)
+                affects_item = (
+                    _affects_item
+                    if isinstance(_affects_item, UUID)
+                    else UUID(_affects_item)
+                )
 
             affects.append(affects_item)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
@@ -210,7 +210,7 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 
@@ -252,7 +252,11 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
             if isinstance(_affects_item, Unset):
                 affects_item = UNSET
             else:
-                affects_item = UUID(_affects_item)
+                affects_item = (
+                    _affects_item
+                    if isinstance(_affects_item, UUID)
+                    else UUID(_affects_item)
+                )
 
             affects.append(affects_item)
 

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_update_response_200.py
@@ -210,7 +210,7 @@ class OsidbApiV1TrackersUpdateResponse200(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 
@@ -252,7 +252,11 @@ class OsidbApiV1TrackersUpdateResponse200(OSIDBModel):
             if isinstance(_affects_item, Unset):
                 affects_item = UNSET
             else:
-                affects_item = UUID(_affects_item)
+                affects_item = (
+                    _affects_item
+                    if isinstance(_affects_item, UUID)
+                    else UUID(_affects_item)
+                )
 
             affects.append(affects_item)
 

--- a/osidb_bindings/bindings/python_client/models/tracker.py
+++ b/osidb_bindings/bindings/python_client/models/tracker.py
@@ -290,7 +290,7 @@ class Tracker(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 
@@ -332,7 +332,11 @@ class Tracker(OSIDBModel):
             if isinstance(_affects_item, Unset):
                 affects_item = UNSET
             else:
-                affects_item = UUID(_affects_item)
+                affects_item = (
+                    _affects_item
+                    if isinstance(_affects_item, UUID)
+                    else UUID(_affects_item)
+                )
 
             affects.append(affects_item)
 

--- a/osidb_bindings/bindings/python_client/models/tracker_post.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_post.py
@@ -276,7 +276,7 @@ class TrackerPost(OSIDBModel):
         if isinstance(_uuid, Unset):
             uuid = UNSET
         else:
-            uuid = UUID(_uuid)
+            uuid = _uuid if isinstance(_uuid, UUID) else UUID(_uuid)
 
         embargoed = d.pop("embargoed", UNSET)
 
@@ -318,7 +318,11 @@ class TrackerPost(OSIDBModel):
             if isinstance(_affects_item, Unset):
                 affects_item = UNSET
             else:
-                affects_item = UUID(_affects_item)
+                affects_item = (
+                    _affects_item
+                    if isinstance(_affects_item, UUID)
+                    else UUID(_affects_item)
+                )
 
             affects.append(affects_item)
 

--- a/osidb_bindings/bindings_config.yml
+++ b/osidb_bindings/bindings_config.yml
@@ -1,5 +1,6 @@
 project_name_override: bindings
 package_name_override: python_client
+package_version_override: 4.6.2
 post_hooks:
    - "ruff check . --fix --extend-select I --config ../../ruff.toml"
    - "ruff format . --config ../../ruff.toml"

--- a/osidb_bindings/templates_0.22.0/property_templates/uuid_property.py.jinja
+++ b/osidb_bindings/templates_0.22.0/property_templates/uuid_property.py.jinja
@@ -3,7 +3,9 @@
     https://github.com/openapi-generators/openapi-python-client/blob/v0.22.0/openapi_python_client/templates/property_templates/uuid_property.py.jinja
 #}
 {% macro construct_function(property, source) %}
-UUID({{ source }})
+{# CHANGE START (3) - handle both UUID and string in UUID format #}
+{{ source }} if isinstance({{source}}, UUID) else UUID({{source}})
+{# CHANGE END (3) #}
 {% endmacro %}
 
 {% from "property_templates/property_macros.py.jinja" import construct_template %}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -47,8 +47,8 @@ update_version() {
     echo "Replacing version in setup.py to ${version}"
     sed -i 's/version="[0-9]*\.[0-9]*\.[0-9]*"/version="'${version}'"/g' setup.py
 
-    echo "Replacing version in pyproject.toml of low level bindings to ${version}"
-    sed -i 's/version = "[0-9]*\.[0-9]*\.[0-9]*"/version = "'${version}'"/g' osidb_bindings/bindings/pyproject.toml
+    echo "Replacing version in bindings_config.yml to ${version}"
+    sed -i 's/package_version_override: [0-9]*\.[0-9]*\.[0-9]*/package_version_override: '${version}'/g' osidb_bindings/bindings_config.yml
 
     echo "Replacing version in constants.py to ${version}"
     sed -i 's/OSIDB_BINDINGS_VERSION: str = "[0-9]*\.[0-9]*\.[0-9]*"/OSIDB_BINDINGS_VERSION: str = "'${version}'"/g' osidb_bindings/constants.py


### PR DESCRIPTION
This PR:
* fixes UUID handling as in older versions of openapi-python-client UUID was not handled by python `UUID` object and it was simply passed over no matter it being a string or actual UUID. This change account for both possibilities