### PR TITLE
Make union fields treated non-required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- make union fields treated as non-required to allow include/exclude fields
+  usage for union fields
 
 ## [4.10.0] - 2025-04-17
 

--- a/osidb_bindings/bindings/python_client/models/affect.py
+++ b/osidb_bindings/bindings/python_client/models/affect.py
@@ -79,7 +79,9 @@ class Affect(OSIDBModel):
             uuid = str(self.uuid)
 
         flaw: Union[None, str]
-        if isinstance(self.flaw, UUID):
+        if isinstance(self.flaw, Unset):
+            flaw = UNSET
+        elif isinstance(self.flaw, UUID):
             flaw = UNSET
             if not isinstance(self.flaw, Unset):
                 flaw = str(self.flaw)
@@ -116,7 +118,9 @@ class Affect(OSIDBModel):
         delegated_not_affected_justification = self.delegated_not_affected_justification
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -274,6 +278,8 @@ class Affect(OSIDBModel):
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -332,6 +338,8 @@ class Affect(OSIDBModel):
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -380,6 +388,8 @@ class Affect(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -409,6 +419,8 @@ class Affect(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -447,6 +459,8 @@ class Affect(OSIDBModel):
         ps_component = _parse_ps_component(d.pop("ps_component", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -487,6 +501,8 @@ class Affect(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/affect_bulk_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_bulk_put_request.py
@@ -57,7 +57,9 @@ class AffectBulkPutRequest(OSIDBModel):
             uuid = str(self.uuid)
 
         flaw: Union[None, str]
-        if isinstance(self.flaw, UUID):
+        if isinstance(self.flaw, Unset):
+            flaw = UNSET
+        elif isinstance(self.flaw, UUID):
             flaw = UNSET
             if not isinstance(self.flaw, Unset):
                 flaw = str(self.flaw)
@@ -181,6 +183,8 @@ class AffectBulkPutRequest(OSIDBModel):
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -216,6 +220,8 @@ class AffectBulkPutRequest(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -245,6 +251,8 @@ class AffectBulkPutRequest(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -283,6 +291,8 @@ class AffectBulkPutRequest(OSIDBModel):
         ps_component = _parse_ps_component(d.pop("ps_component", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -323,6 +333,8 @@ class AffectBulkPutRequest(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/affect_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_post_request.py
@@ -46,7 +46,9 @@ class AffectPostRequest(OSIDBModel):
 
     def to_dict(self) -> dict[str, Any]:
         flaw: Union[None, str]
-        if isinstance(self.flaw, UUID):
+        if isinstance(self.flaw, Unset):
+            flaw = UNSET
+        elif isinstance(self.flaw, UUID):
             flaw = UNSET
             if not isinstance(self.flaw, Unset):
                 flaw = str(self.flaw)
@@ -281,6 +283,8 @@ class AffectPostRequest(OSIDBModel):
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -309,6 +313,8 @@ class AffectPostRequest(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -338,6 +344,8 @@ class AffectPostRequest(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -376,6 +384,8 @@ class AffectPostRequest(OSIDBModel):
         ps_component = _parse_ps_component(d.pop("ps_component", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -416,6 +426,8 @@ class AffectPostRequest(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/affect_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/affect_report_data.py
@@ -101,6 +101,8 @@ class AffectReportData(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -130,6 +132,8 @@ class AffectReportData(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/affect_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_request.py
@@ -51,7 +51,9 @@ class AffectRequest(OSIDBModel):
 
     def to_dict(self) -> dict[str, Any]:
         flaw: Union[None, str]
-        if isinstance(self.flaw, UUID):
+        if isinstance(self.flaw, Unset):
+            flaw = UNSET
+        elif isinstance(self.flaw, UUID):
             flaw = UNSET
             if not isinstance(self.flaw, Unset):
                 flaw = str(self.flaw)
@@ -298,6 +300,8 @@ class AffectRequest(OSIDBModel):
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -333,6 +337,8 @@ class AffectRequest(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -362,6 +368,8 @@ class AffectRequest(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -400,6 +408,8 @@ class AffectRequest(OSIDBModel):
         ps_component = _parse_ps_component(d.pop("ps_component", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -440,6 +450,8 @@ class AffectRequest(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/erratum.py
+++ b/osidb_bindings/bindings/python_client/models/erratum.py
@@ -36,7 +36,9 @@ class Erratum(OSIDBModel):
         advisory_name = self.advisory_name
 
         shipped_dt: Union[None, str]
-        if isinstance(self.shipped_dt, datetime.datetime):
+        if isinstance(self.shipped_dt, Unset):
+            shipped_dt = UNSET
+        elif isinstance(self.shipped_dt, datetime.datetime):
             shipped_dt = UNSET
             if not isinstance(self.shipped_dt, Unset):
                 shipped_dt = self.shipped_dt.isoformat()
@@ -76,6 +78,8 @@ class Erratum(OSIDBModel):
 
         def _parse_shipped_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
+                return data
+            if isinstance(data, Unset):
                 return data
             try:
                 if not isinstance(data, str):

--- a/osidb_bindings/bindings/python_client/models/flaw.py
+++ b/osidb_bindings/bindings/python_client/models/flaw.py
@@ -208,6 +208,8 @@ class Flaw(OSIDBModel):
             classification = self.classification.to_dict()
 
         task_key: Union[None, str]
+        if isinstance(self.task_key, Unset):
+            task_key = UNSET
         task_key = self.task_key
 
         alerts: list[dict[str, Any]] = UNSET
@@ -561,6 +563,8 @@ class Flaw(OSIDBModel):
         def _parse_task_key(data: object) -> Union[None, str]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             return cast(Union[None, str], data)
 
         task_key = _parse_task_key(d.pop("task_key", UNSET))
@@ -587,6 +591,8 @@ class Flaw(OSIDBModel):
         cve_id = _parse_cve_id(d.pop("cve_id", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -622,6 +628,8 @@ class Flaw(OSIDBModel):
         def _parse_requires_cve_description(
             data: object,
         ) -> Union[BlankEnum, RequiresCveDescriptionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -683,6 +691,8 @@ class Flaw(OSIDBModel):
         unembargo_dt = _parse_unembargo_dt(d.pop("unembargo_dt", UNSET))
 
         def _parse_source(data: object) -> Union[BlankEnum, SourceBe0Enum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -738,6 +748,8 @@ class Flaw(OSIDBModel):
         def _parse_major_incident_state(
             data: object,
         ) -> Union[BlankEnum, MajorIncidentStateEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -801,6 +813,8 @@ class Flaw(OSIDBModel):
         def _parse_nist_cvss_validation(
             data: object,
         ) -> Union[BlankEnum, NistCvssValidationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/flaw_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_post_request.py
@@ -512,6 +512,8 @@ class FlawPostRequest(OSIDBModel):
         cve_id = _parse_cve_id(d.pop("cve_id", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -547,6 +549,8 @@ class FlawPostRequest(OSIDBModel):
         def _parse_requires_cve_description(
             data: object,
         ) -> Union[BlankEnum, RequiresCveDescriptionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -608,6 +612,8 @@ class FlawPostRequest(OSIDBModel):
         unembargo_dt = _parse_unembargo_dt(d.pop("unembargo_dt", UNSET))
 
         def _parse_source(data: object) -> Union[BlankEnum, SourceBe0Enum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -663,6 +669,8 @@ class FlawPostRequest(OSIDBModel):
         def _parse_major_incident_state(
             data: object,
         ) -> Union[BlankEnum, MajorIncidentStateEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -726,6 +734,8 @@ class FlawPostRequest(OSIDBModel):
         def _parse_nist_cvss_validation(
             data: object,
         ) -> Union[BlankEnum, NistCvssValidationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/flaw_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_request.py
@@ -534,6 +534,8 @@ class FlawRequest(OSIDBModel):
         cve_id = _parse_cve_id(d.pop("cve_id", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -569,6 +571,8 @@ class FlawRequest(OSIDBModel):
         def _parse_requires_cve_description(
             data: object,
         ) -> Union[BlankEnum, RequiresCveDescriptionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -630,6 +634,8 @@ class FlawRequest(OSIDBModel):
         unembargo_dt = _parse_unembargo_dt(d.pop("unembargo_dt", UNSET))
 
         def _parse_source(data: object) -> Union[BlankEnum, SourceBe0Enum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -685,6 +691,8 @@ class FlawRequest(OSIDBModel):
         def _parse_major_incident_state(
             data: object,
         ) -> Union[BlankEnum, MajorIncidentStateEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -748,6 +756,8 @@ class FlawRequest(OSIDBModel):
         def _parse_nist_cvss_validation(
             data: object,
         ) -> Union[BlankEnum, NistCvssValidationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
@@ -86,7 +86,9 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
             uuid = str(self.uuid)
 
         flaw: Union[None, str]
-        if isinstance(self.flaw, UUID):
+        if isinstance(self.flaw, Unset):
+            flaw = UNSET
+        elif isinstance(self.flaw, UUID):
             flaw = UNSET
             if not isinstance(self.flaw, Unset):
                 flaw = str(self.flaw)
@@ -123,7 +125,9 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         delegated_not_affected_justification = self.delegated_not_affected_justification
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -299,6 +303,8 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -357,6 +363,8 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -405,6 +413,8 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -434,6 +444,8 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -472,6 +484,8 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         ps_component = _parse_ps_component(d.pop("ps_component", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -512,6 +526,8 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
@@ -86,7 +86,9 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
             uuid = str(self.uuid)
 
         flaw: Union[None, str]
-        if isinstance(self.flaw, UUID):
+        if isinstance(self.flaw, Unset):
+            flaw = UNSET
+        elif isinstance(self.flaw, UUID):
             flaw = UNSET
             if not isinstance(self.flaw, Unset):
                 flaw = str(self.flaw)
@@ -123,7 +125,9 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         delegated_not_affected_justification = self.delegated_not_affected_justification
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -299,6 +303,8 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -357,6 +363,8 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -405,6 +413,8 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -434,6 +444,8 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -472,6 +484,8 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         ps_component = _parse_ps_component(d.pop("ps_component", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -512,6 +526,8 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
@@ -86,7 +86,9 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
             uuid = str(self.uuid)
 
         flaw: Union[None, str]
-        if isinstance(self.flaw, UUID):
+        if isinstance(self.flaw, Unset):
+            flaw = UNSET
+        elif isinstance(self.flaw, UUID):
             flaw = UNSET
             if not isinstance(self.flaw, Unset):
                 flaw = str(self.flaw)
@@ -123,7 +125,9 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         delegated_not_affected_justification = self.delegated_not_affected_justification
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -299,6 +303,8 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         def _parse_flaw(data: object) -> Union[None, UUID]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -357,6 +363,8 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -405,6 +413,8 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         def _parse_affectedness(
             data: object,
         ) -> Union[AffectednessEnum, BlankEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -434,6 +444,8 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         affectedness = _parse_affectedness(d.pop("affectedness", UNSET))
 
         def _parse_resolution(data: object) -> Union[BlankEnum, ResolutionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -472,6 +484,8 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         ps_component = _parse_ps_component(d.pop("ps_component", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -512,6 +526,8 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
@@ -215,6 +215,8 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
             classification = self.classification.to_dict()
 
         task_key: Union[None, str]
+        if isinstance(self.task_key, Unset):
+            task_key = UNSET
         task_key = self.task_key
 
         alerts: list[dict[str, Any]] = UNSET
@@ -586,6 +588,8 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         def _parse_task_key(data: object) -> Union[None, str]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             return cast(Union[None, str], data)
 
         task_key = _parse_task_key(d.pop("task_key", UNSET))
@@ -612,6 +616,8 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         cve_id = _parse_cve_id(d.pop("cve_id", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -647,6 +653,8 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         def _parse_requires_cve_description(
             data: object,
         ) -> Union[BlankEnum, RequiresCveDescriptionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -708,6 +716,8 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         unembargo_dt = _parse_unembargo_dt(d.pop("unembargo_dt", UNSET))
 
         def _parse_source(data: object) -> Union[BlankEnum, SourceBe0Enum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -763,6 +773,8 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         def _parse_major_incident_state(
             data: object,
         ) -> Union[BlankEnum, MajorIncidentStateEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -826,6 +838,8 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         def _parse_nist_cvss_validation(
             data: object,
         ) -> Union[BlankEnum, NistCvssValidationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
@@ -215,6 +215,8 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
             classification = self.classification.to_dict()
 
         task_key: Union[None, str]
+        if isinstance(self.task_key, Unset):
+            task_key = UNSET
         task_key = self.task_key
 
         alerts: list[dict[str, Any]] = UNSET
@@ -586,6 +588,8 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         def _parse_task_key(data: object) -> Union[None, str]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             return cast(Union[None, str], data)
 
         task_key = _parse_task_key(d.pop("task_key", UNSET))
@@ -612,6 +616,8 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         cve_id = _parse_cve_id(d.pop("cve_id", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -647,6 +653,8 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         def _parse_requires_cve_description(
             data: object,
         ) -> Union[BlankEnum, RequiresCveDescriptionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -708,6 +716,8 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         unembargo_dt = _parse_unembargo_dt(d.pop("unembargo_dt", UNSET))
 
         def _parse_source(data: object) -> Union[BlankEnum, SourceBe0Enum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -763,6 +773,8 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         def _parse_major_incident_state(
             data: object,
         ) -> Union[BlankEnum, MajorIncidentStateEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -826,6 +838,8 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         def _parse_nist_cvss_validation(
             data: object,
         ) -> Union[BlankEnum, NistCvssValidationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
@@ -215,6 +215,8 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
             classification = self.classification.to_dict()
 
         task_key: Union[None, str]
+        if isinstance(self.task_key, Unset):
+            task_key = UNSET
         task_key = self.task_key
 
         alerts: list[dict[str, Any]] = UNSET
@@ -586,6 +588,8 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         def _parse_task_key(data: object) -> Union[None, str]:
             if data is None:
                 return data
+            if isinstance(data, Unset):
+                return data
             return cast(Union[None, str], data)
 
         task_key = _parse_task_key(d.pop("task_key", UNSET))
@@ -612,6 +616,8 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         cve_id = _parse_cve_id(d.pop("cve_id", UNSET))
 
         def _parse_impact(data: object) -> Union[BlankEnum, ImpactEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -647,6 +653,8 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         def _parse_requires_cve_description(
             data: object,
         ) -> Union[BlankEnum, RequiresCveDescriptionEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -708,6 +716,8 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         unembargo_dt = _parse_unembargo_dt(d.pop("unembargo_dt", UNSET))
 
         def _parse_source(data: object) -> Union[BlankEnum, SourceBe0Enum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -763,6 +773,8 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         def _parse_major_incident_state(
             data: object,
         ) -> Union[BlankEnum, MajorIncidentStateEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:
@@ -826,6 +838,8 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         def _parse_nist_cvss_validation(
             data: object,
         ) -> Union[BlankEnum, NistCvssValidationEnum, Unset]:
+            if data is None:
+                return data
             if isinstance(data, Unset):
                 return data
             try:

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_create_response_201.py
@@ -84,7 +84,9 @@ class OsidbApiV1TrackersCreateResponse201(OSIDBModel):
         resolution = self.resolution
 
         not_affected_justification: str
-        if isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
+        if isinstance(self.not_affected_justification, Unset):
+            not_affected_justification = UNSET
+        elif isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
             not_affected_justification = UNSET
             if not isinstance(self.not_affected_justification, Unset):
                 not_affected_justification = NotAffectedJustificationEnum(
@@ -119,7 +121,9 @@ class OsidbApiV1TrackersCreateResponse201(OSIDBModel):
                 special_handling.append(special_handling_item)
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -235,6 +239,10 @@ class OsidbApiV1TrackersCreateResponse201(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -295,6 +303,8 @@ class OsidbApiV1TrackersCreateResponse201(OSIDBModel):
 
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
+                return data
+            if isinstance(data, Unset):
                 return data
             try:
                 if not isinstance(data, str):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
@@ -86,7 +86,9 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
         resolution = self.resolution
 
         not_affected_justification: str
-        if isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
+        if isinstance(self.not_affected_justification, Unset):
+            not_affected_justification = UNSET
+        elif isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
             not_affected_justification = UNSET
             if not isinstance(self.not_affected_justification, Unset):
                 not_affected_justification = NotAffectedJustificationEnum(
@@ -121,7 +123,9 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
                 special_handling.append(special_handling_item)
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -241,6 +245,10 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -301,6 +309,8 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
 
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
+                return data
+            if isinstance(data, Unset):
                 return data
             try:
                 if not isinstance(data, str):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_update_response_200.py
@@ -86,7 +86,9 @@ class OsidbApiV1TrackersUpdateResponse200(OSIDBModel):
         resolution = self.resolution
 
         not_affected_justification: str
-        if isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
+        if isinstance(self.not_affected_justification, Unset):
+            not_affected_justification = UNSET
+        elif isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
             not_affected_justification = UNSET
             if not isinstance(self.not_affected_justification, Unset):
                 not_affected_justification = NotAffectedJustificationEnum(
@@ -121,7 +123,9 @@ class OsidbApiV1TrackersUpdateResponse200(OSIDBModel):
                 special_handling.append(special_handling_item)
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -241,6 +245,10 @@ class OsidbApiV1TrackersUpdateResponse200(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -301,6 +309,8 @@ class OsidbApiV1TrackersUpdateResponse200(OSIDBModel):
 
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
+                return data
+            if isinstance(data, Unset):
                 return data
             try:
                 if not isinstance(data, str):

--- a/osidb_bindings/bindings/python_client/models/tracker.py
+++ b/osidb_bindings/bindings/python_client/models/tracker.py
@@ -79,7 +79,9 @@ class Tracker(OSIDBModel):
         resolution = self.resolution
 
         not_affected_justification: str
-        if isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
+        if isinstance(self.not_affected_justification, Unset):
+            not_affected_justification = UNSET
+        elif isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
             not_affected_justification = UNSET
             if not isinstance(self.not_affected_justification, Unset):
                 not_affected_justification = NotAffectedJustificationEnum(
@@ -114,7 +116,9 @@ class Tracker(OSIDBModel):
                 special_handling.append(special_handling_item)
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -216,6 +220,10 @@ class Tracker(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -276,6 +284,8 @@ class Tracker(OSIDBModel):
 
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
+                return data
+            if isinstance(data, Unset):
                 return data
             try:
                 if not isinstance(data, str):

--- a/osidb_bindings/bindings/python_client/models/tracker_post.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_post.py
@@ -77,7 +77,9 @@ class TrackerPost(OSIDBModel):
         resolution = self.resolution
 
         not_affected_justification: str
-        if isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
+        if isinstance(self.not_affected_justification, Unset):
+            not_affected_justification = UNSET
+        elif isinstance(self.not_affected_justification, NotAffectedJustificationEnum):
             not_affected_justification = UNSET
             if not isinstance(self.not_affected_justification, Unset):
                 not_affected_justification = NotAffectedJustificationEnum(
@@ -112,7 +114,9 @@ class TrackerPost(OSIDBModel):
                 special_handling.append(special_handling_item)
 
         resolved_dt: Union[None, str]
-        if isinstance(self.resolved_dt, datetime.datetime):
+        if isinstance(self.resolved_dt, Unset):
+            resolved_dt = UNSET
+        elif isinstance(self.resolved_dt, datetime.datetime):
             resolved_dt = UNSET
             if not isinstance(self.resolved_dt, Unset):
                 resolved_dt = self.resolved_dt.isoformat()
@@ -210,6 +214,10 @@ class TrackerPost(OSIDBModel):
         def _parse_not_affected_justification(
             data: object,
         ) -> Union[BlankEnum, NotAffectedJustificationEnum]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
             try:
                 if not isinstance(data, str):
                     raise TypeError()
@@ -270,6 +278,8 @@ class TrackerPost(OSIDBModel):
 
         def _parse_resolved_dt(data: object) -> Union[None, datetime.datetime]:
             if data is None:
+                return data
+            if isinstance(data, Unset):
                 return data
             try:
                 if not isinstance(data, str):

--- a/osidb_bindings/templates_0.22.0/property_templates/union_property.py.jinja
+++ b/osidb_bindings/templates_0.22.0/property_templates/union_property.py.jinja
@@ -4,14 +4,16 @@
 #}
 {% macro construct(property, source) %}
 def _parse_{{ property.python_name }}(data: object) -> {{ property.get_type_string() }}:
-    {% if "None" in property.get_type_strings_in_union(json=True, multipart=False) %}
+{# CHANGE START (1) - make all the fields treated as non-required #}
+{#    {% if "None" in property.get_type_strings_in_union(json=True, multipart=False) %}#}
     if data is None:
         return data
-    {% endif %}
-    {% if "Unset" in property.get_type_strings_in_union(json=True, multipart=False) %}
+{#    {% endif %}#}
+{#    {% if "Unset" in property.get_type_strings_in_union(json=True, multipart=False) %}#}
     if isinstance(data, Unset):
         return data
-    {% endif %}
+{#    {% endif %}#}
+{# CHANGE END (1) #}
     {% set ns = namespace(contains_unmodified_properties = false) %}
     {% for inner_property in property.inner_properties %}
     {% import "property_templates/" + inner_property.template as inner_template %}
@@ -47,11 +49,13 @@ def _parse_{{ property.python_name }}(data: object) -> {{ property.get_type_stri
 {% set ns = namespace(contains_properties_without_transform = false, contains_modified_properties = not property.required, has_if = false) %}
 {% if declare_type %}{{ destination }}: {{ property.get_type_string(json=True, multipart=False) }}{% endif %}
 
-{% if not property.required %}
+{# CHANGE START (2) - make all the fields treated as non-required #}
+{#{% if not property.required %}#}
 if isinstance({{ source }}, Unset):
     {{ destination }} = UNSET
     {% set ns.has_if = true %}
-{% endif %}
+{#{% endif %}#}
+{# CHANGE END (2) #}
 {% for inner_property in property.inner_properties %}
     {% import "property_templates/" + inner_property.template as inner_template %}
     {% if not inner_template.transform %}

--- a/osidb_bindings/templates_0.22.0/property_templates/union_property.py.jinja
+++ b/osidb_bindings/templates_0.22.0/property_templates/union_property.py.jinja
@@ -1,0 +1,103 @@
+{#
+    This is a custom template derived from:
+    https://github.com/openapi-generators/openapi-python-client/blob/v0.22.0/openapi_python_client/templates/property_templates/union_property.py.jinja
+#}
+{% macro construct(property, source) %}
+def _parse_{{ property.python_name }}(data: object) -> {{ property.get_type_string() }}:
+    {% if "None" in property.get_type_strings_in_union(json=True, multipart=False) %}
+    if data is None:
+        return data
+    {% endif %}
+    {% if "Unset" in property.get_type_strings_in_union(json=True, multipart=False) %}
+    if isinstance(data, Unset):
+        return data
+    {% endif %}
+    {% set ns = namespace(contains_unmodified_properties = false) %}
+    {% for inner_property in property.inner_properties %}
+    {% import "property_templates/" + inner_property.template as inner_template %}
+        {% if not inner_template.construct %}
+            {% set ns.contains_unmodified_properties = true %}
+            {% continue %}
+        {% endif %}
+    {% if inner_template.check_type_for_construct and (not loop.last or ns.contains_unmodified_properties) %}
+    try:
+        if not {{ inner_template.check_type_for_construct(inner_property, "data") }}:
+            raise TypeError()
+        {{ inner_template.construct(inner_property, "data") | indent(8) }}
+        return {{ inner_property.python_name }}
+    except: # noqa: E722
+        pass
+    {% else  %}{# Don't do try/except for the last one nor any properties with no type checking #}
+    {% if inner_template.check_type_for_construct %}
+    if not {{ inner_template.check_type_for_construct(inner_property, "data") }}:
+        raise TypeError()
+    {% endif %}
+    {{ inner_template.construct(inner_property, "data") | indent(4) }}
+    return {{ inner_property.python_name }}
+    {% endif %}
+    {% endfor %}
+    {% if ns.contains_unmodified_properties %}
+    return cast({{ property.get_type_string() }}, data)
+    {% endif %}
+
+{{ property.python_name }} = _parse_{{ property.python_name }}({{ source }})
+{% endmacro %}
+
+{% macro transform(property, source, destination, declare_type=True) %}
+{% set ns = namespace(contains_properties_without_transform = false, contains_modified_properties = not property.required, has_if = false) %}
+{% if declare_type %}{{ destination }}: {{ property.get_type_string(json=True, multipart=False) }}{% endif %}
+
+{% if not property.required %}
+if isinstance({{ source }}, Unset):
+    {{ destination }} = UNSET
+    {% set ns.has_if = true %}
+{% endif %}
+{% for inner_property in property.inner_properties %}
+    {% import "property_templates/" + inner_property.template as inner_template %}
+    {% if not inner_template.transform %}
+        {% set ns.contains_properties_without_transform = true %}
+        {% continue %}
+    {% else %}
+        {% set ns.contains_modified_properties = true %}
+    {% endif %}
+    {% if not ns.has_if %}
+if isinstance({{ source }}, {{ inner_property.get_instance_type_string() }}):
+        {% set ns.has_if = true %}
+    {% elif not loop.last or ns.contains_properties_without_transform %}
+elif isinstance({{ source }}, {{ inner_property.get_instance_type_string() }}):
+    {% else %}
+else:
+    {% endif %}
+    {{ inner_template.transform(inner_property, source, destination, declare_type=False) | indent(4) }}
+{% endfor %}
+{% if ns.contains_properties_without_transform and ns.contains_modified_properties %}
+else:
+    {{ destination }} = {{ source }}
+{%- elif ns.contains_properties_without_transform %}
+{{ destination }} = {{ source }}
+{%- endif %}
+{% endmacro %}
+
+
+{% macro transform_multipart(property, source, destination) %}
+{% set ns = namespace(has_if = false) %}
+{{ destination }}: {{ property.get_type_string(json=False, multipart=True) }}
+
+{% if not property.required %}
+if isinstance({{ source }}, Unset):
+    {{ destination }} = UNSET
+    {% set ns.has_if = true %}
+{% endif %}
+{% for inner_property in property.inner_properties %}
+{% if not ns.has_if %}
+if isinstance({{ source }}, {{ inner_property.get_instance_type_string() }}):
+{% set ns.has_if = true %}
+{% elif not loop.last %}
+elif isinstance({{ source }}, {{ inner_property.get_instance_type_string() }}):
+{% else %}
+else:
+{% endif %}
+{% import "property_templates/" + inner_property.template as inner_template %}
+    {{ inner_template.transform_multipart(inner_property, source, destination) | indent(4) | trim }}
+{% endfor %}
+{% endmacro %}


### PR DESCRIPTION
This PR:
* adds a custom template for union fields
* tweaks union fields template to always consider union field non-required for the purpose of include/exclude fields logic