### PR TITLE
README.md: fix Usage example so that it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ osidb_session.status()
 flaw = osidb_session.flaws.retrieve(id="CVE-1111-2222")
 
 # Fields can be accessed directly via attributes
-flaw.summary
+flaw.title
 flaw.impact
 
 # or the flaw can be converted into dict
 flaw_dict = flaw.to_dict()
-flaw_dict["summary"]
+flaw_dict["title"]
 flaw_dict["impact"]
 
 # Retrieving multiple flaws
-all_flaws = osidb_session.flaw.retrieve_list()
+all_flaws = osidb_session.flaws.retrieve_list()
 
 # All query params listed in OpenAPI schema can be passed as well
 filtered_flaws = osidb_session.flaws.retrieve_list(impact="IMPORTANT", tracker_ids=["111111", "222222"])


### PR DESCRIPTION
... out of the box.  The previously accessed fields were not available in the objects being accessed:
```
Traceback (most recent call last):
  File "/tmp/xxx.py", line 15, in <module>
    flaw.summary
AttributeError: 'OsidbApiV1FlawsRetrieveResponse200' object has no attribute 'summary'

Traceback (most recent call last):
  File "/tmp/xxx.py", line 20, in <module>
    flaw_dict["summary"]
    ~~~~~~~~~^^^^^^^^^^^
KeyError: 'summary'

Traceback (most recent call last):
  File "/tmp/xxx.py", line 24, in <module>
    all_flaws = osidb_session.flaw.retrieve_list()
                ^^^^^^^^^^^^^^^^^^
AttributeError: 'Session' object has no attribute 'flaw'. Did you mean: 'flaws'?
```