### PR TITLE
switch to rpkg for copr build

### DIFF
--- a/osidb_bindings.spec
+++ b/osidb_bindings.spec
@@ -8,9 +8,9 @@ Release:        %{release}
 Summary:        OSIDB Python Bindings
 
 URL:            https://github.com/RedHatProductSecurity/osdib-bindings
-Source0:        %{name}-%{version}.tar.gz
+Source0:        {{{ git_dir_pack }}}
+VCS:            {{{ git_dir_vcs }}}
 License: MIT
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 
 BuildArch:      noarch
 AutoReqProv: no
@@ -29,7 +29,7 @@ Requires:       python3-requests-gssapi
 Python Client bindings for OSIDB
 
 %prep
-%autosetup -n %{name}-%{version} -p1
+{{{ git_dir_setup_macro }}}
 
 %generate_buildrequires
 


### PR DESCRIPTION
Switch to the rpkg mode for Copr build. Seems to work, see:
https://copr.fedorainfracloud.org/coprs/jazinner/osidb-bindings/build/9256169/