### PR TITLE
Fix get_fields classmethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- fix get_fields model method
 
 ## [4.14.0] - 2025-07-24
 

--- a/osidb_bindings/bindings/python_client/models/affect.py
+++ b/osidb_bindings/bindings/python_client/models/affect.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.affectedness_enum import AffectednessEnum
@@ -571,32 +572,9 @@ class Affect(OSIDBModel):
         affect.additional_properties = d
         return affect
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "flaw": Union[None, UUID],
-            "ps_module": str,
-            "cve_id": str,
-            "ps_product": str,
-            "trackers": list["Tracker"],
-            "delegated_resolution": str,
-            "cvss_scores": list["AffectCVSS"],
-            "delegated_not_affected_justification": str,
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "ps_component": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "purl": Union[None, str],
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_bulk_post_put_response.py
+++ b/osidb_bindings/bindings/python_client/models/affect_bulk_post_put_response.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -64,11 +65,9 @@ class AffectBulkPostPutResponse(OSIDBModel):
         affect_bulk_post_put_response.additional_properties = d
         return affect_bulk_post_put_response
 
-    @staticmethod
-    def get_fields():
-        return {
-            "results": list["Affect"],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_bulk_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_bulk_put_request.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.affectedness_enum import AffectednessEnum
@@ -386,23 +387,9 @@ class AffectBulkPutRequest(OSIDBModel):
         affect_bulk_put_request.additional_properties = d
         return affect_bulk_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "flaw": Union[None, UUID],
-            "ps_module": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "ps_component": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "purl": Union[None, str],
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_cvss.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -215,21 +216,9 @@ class AffectCVSS(OSIDBModel):
         affect_cvss.additional_properties = d
         return affect_cvss
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_cvss_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.cvss_version_enum import CvssVersionEnum
 from ..models.issuer_enum import IssuerEnum
@@ -144,15 +145,9 @@ class AffectCVSSPostRequest(OSIDBModel):
         affect_cvss_post_request.additional_properties = d
         return affect_cvss_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_cvss_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss_put_request.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -169,16 +170,9 @@ class AffectCVSSPutRequest(OSIDBModel):
         affect_cvss_put_request.additional_properties = d
         return affect_cvss_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_cvss_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss_request.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -141,17 +142,9 @@ class AffectCVSSRequest(OSIDBModel):
         affect_cvss_request.additional_properties = d
         return affect_cvss_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_cvssv2.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvssv2.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -215,21 +216,9 @@ class AffectCVSSV2(OSIDBModel):
         affect_cvssv2.additional_properties = d
         return affect_cvssv2
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_cvssv2_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvssv2_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.cvss_version_enum import CvssVersionEnum
 from ..types import UNSET, OSIDBModel, Unset
@@ -121,14 +122,9 @@ class AffectCVSSV2PostRequest(OSIDBModel):
         affect_cvssv2_post_request.additional_properties = d
         return affect_cvssv2_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "comment": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_cvssv2_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvssv2_put_request.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -146,15 +147,9 @@ class AffectCVSSV2PutRequest(OSIDBModel):
         affect_cvssv2_put_request.additional_properties = d
         return affect_cvssv2_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "comment": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_post_request.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.affectedness_enum import AffectednessEnum
 from ..models.blank_enum import BlankEnum
@@ -477,21 +478,9 @@ class AffectPostRequest(OSIDBModel):
         affect_post_request.additional_properties = d
         return affect_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": Union[None, UUID],
-            "ps_module": str,
-            "embargoed": bool,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "ps_component": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "purl": Union[None, str],
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/affect_report_data.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.affectedness_enum import AffectednessEnum
 from ..models.blank_enum import BlankEnum
@@ -185,15 +186,9 @@ class AffectReportData(OSIDBModel):
         affect_report_data.additional_properties = d
         return affect_report_data
 
-    @staticmethod
-    def get_fields():
-        return {
-            "ps_module": str,
-            "ps_component": str,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "trackers": list["TrackerReportData"],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/affect_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_request.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.affectedness_enum import AffectednessEnum
@@ -502,22 +503,9 @@ class AffectRequest(OSIDBModel):
         affect_request.additional_properties = d
         return affect_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": Union[None, UUID],
-            "ps_module": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "ps_component": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "purl": Union[None, str],
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/alert.py
+++ b/osidb_bindings/bindings/python_client/models/alert.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.alert_type_enum import AlertTypeEnum
 from ..types import UNSET, OSIDBModel, Unset
@@ -120,17 +121,9 @@ class Alert(OSIDBModel):
         alert.additional_properties = d
         return alert
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "name": str,
-            "description": str,
-            "parent_uuid": UUID,
-            "parent_model": str,
-            "alert_type": AlertTypeEnum,
-            "resolution_steps": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/audit.py
+++ b/osidb_bindings/bindings/python_client/models/audit.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -123,18 +124,9 @@ class Audit(OSIDBModel):
         audit.additional_properties = d
         return audit
 
-    @staticmethod
-    def get_fields():
-        return {
-            "pgh_created_at": datetime.datetime,
-            "pgh_slug": str,
-            "pgh_obj_model": str,
-            "pgh_label": str,
-            "pgh_diff": Any,
-            "pgh_data": str,
-            "pgh_obj_id": Union[None, str],
-            "pgh_context": Any,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/audit_request.py
+++ b/osidb_bindings/bindings/python_client/models/audit_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -139,16 +140,9 @@ class AuditRequest(OSIDBModel):
         audit_request.additional_properties = d
         return audit_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "pgh_slug": str,
-            "pgh_obj_model": str,
-            "pgh_label": str,
-            "pgh_diff": Any,
-            "pgh_obj_id": Union[None, str],
-            "pgh_context": Any,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/auth_token_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_create_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -94,16 +95,9 @@ class AuthTokenCreateResponse200(OSIDBModel):
         auth_token_create_response_200.additional_properties = d
         return auth_token_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "access": str,
-            "refresh": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/auth_token_refresh_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_refresh_create_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -85,15 +86,9 @@ class AuthTokenRefreshCreateResponse200(OSIDBModel):
         auth_token_refresh_create_response_200.additional_properties = d
         return auth_token_refresh_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "access": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/auth_token_refresh_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_refresh_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -85,15 +86,9 @@ class AuthTokenRefreshRetrieveResponse200(OSIDBModel):
         auth_token_refresh_retrieve_response_200.additional_properties = d
         return auth_token_refresh_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "access": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/auth_token_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -94,16 +95,9 @@ class AuthTokenRetrieveResponse200(OSIDBModel):
         auth_token_retrieve_response_200.additional_properties = d
         return auth_token_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "access": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "refresh": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/auth_token_verify_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_verify_create_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class AuthTokenVerifyCreateResponse200(OSIDBModel):
         auth_token_verify_create_response_200.additional_properties = d
         return auth_token_verify_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -119,17 +120,9 @@ class CollectorsApiV1StatusRetrieveResponse200(OSIDBModel):
         collectors_api_v1_status_retrieve_response_200.additional_properties = d
         return collectors_api_v1_status_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "collectors": list[
-                "CollectorsApiV1StatusRetrieveResponse200CollectorsItem"
-            ],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.collectors_api_v1_status_retrieve_response_200_collectors_item_data import (
@@ -208,20 +209,9 @@ class CollectorsApiV1StatusRetrieveResponse200CollectorsItem(OSIDBModel):
         collectors_api_v1_status_retrieve_response_200_collectors_item.additional_properties = d
         return collectors_api_v1_status_retrieve_response_200_collectors_item
 
-    @staticmethod
-    def get_fields():
-        return {
-            "data": CollectorsApiV1StatusRetrieveResponse200CollectorsItemData,
-            "depends_on": list[str],
-            "error": Union[
-                "CollectorsApiV1StatusRetrieveResponse200CollectorsItemErrorType0", None
-            ],
-            "is_complete": bool,
-            "is_up2date": bool,
-            "data_models": list[str],
-            "state": CollectorsApiV1StatusRetrieveResponse200CollectorsItemState,
-            "updated_until": datetime.datetime,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item_error_type_0.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item_error_type_0.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -34,9 +35,9 @@ class CollectorsApiV1StatusRetrieveResponse200CollectorsItemErrorType0(OSIDBMode
             collectors_api_v1_status_retrieve_response_200_collectors_item_error_type_0
         )
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/collectors_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_healthy_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class CollectorsHealthyRetrieveResponse200(OSIDBModel):
         collectors_healthy_retrieve_response_200.additional_properties = d
         return collectors_healthy_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/collectors_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -87,15 +88,9 @@ class CollectorsRetrieveResponse200(OSIDBModel):
         collectors_retrieve_response_200.additional_properties = d
         return collectors_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "index": list[str],
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/comment.py
+++ b/osidb_bindings/bindings/python_client/models/comment.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -173,19 +174,9 @@ class Comment(OSIDBModel):
         comment.additional_properties = d
         return comment
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "text": str,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "external_system_id": str,
-            "order": Union[None, int],
-            "creator": str,
-            "is_private": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/comment_request.py
+++ b/osidb_bindings/bindings/python_client/models/comment_request.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -107,16 +108,9 @@ class CommentRequest(OSIDBModel):
         comment_request.additional_properties = d
         return comment_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "text": str,
-            "updated_dt": datetime.datetime,
-            "external_system_id": str,
-            "order": Union[None, int],
-            "creator": str,
-            "is_private": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/epss.py
+++ b/osidb_bindings/bindings/python_client/models/epss.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -49,12 +50,9 @@ class EPSS(OSIDBModel):
         epss.additional_properties = d
         return epss
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve": str,
-            "epss": float,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/erratum.py
+++ b/osidb_bindings/bindings/python_client/models/erratum.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -123,15 +124,9 @@ class Erratum(OSIDBModel):
         erratum.additional_properties = d
         return erratum
 
-    @staticmethod
-    def get_fields():
-        return {
-            "et_id": int,
-            "advisory_name": str,
-            "shipped_dt": Union[None, datetime.datetime],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploit_only_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/exploit_only_report_data.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.exploit_only_report_data_source_enum import (
@@ -136,16 +137,9 @@ class ExploitOnlyReportData(OSIDBModel):
         exploit_only_report_data.additional_properties = d
         return exploit_only_report_data
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve": str,
-            "source": ExploitOnlyReportDataSourceEnum,
-            "maturity_preliminary": MaturityPreliminaryEnum,
-            "flaw": bool,
-            "date": Union[None, datetime.date],
-            "reference": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_collect_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_collect_update_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -85,15 +86,9 @@ class ExploitsApiV1CollectUpdateResponse200(OSIDBModel):
         exploits_api_v1_collect_update_response_200.additional_properties = d
         return exploits_api_v1_collect_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "result_cisa": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -111,16 +112,9 @@ class ExploitsApiV1CveMapRetrieveResponse200(OSIDBModel):
         exploits_api_v1_cve_map_retrieve_response_200.additional_properties = d
         return exploits_api_v1_cve_map_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cves": ExploitsApiV1CveMapRetrieveResponse200Cves,
-            "dt": datetime.datetime,
-            "env": str,
-            "page_size": int,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200_cves.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200_cves.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -28,9 +29,9 @@ class ExploitsApiV1CveMapRetrieveResponse200Cves(OSIDBModel):
         exploits_api_v1_cve_map_retrieve_response_200_cves.additional_properties = d
         return exploits_api_v1_cve_map_retrieve_response_200_cves
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_epss_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_epss_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class ExploitsApiV1EpssListResponse200(OSIDBModel):
         exploits_api_v1_epss_list_response_200.additional_properties = d
         return exploits_api_v1_epss_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["EPSS"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_flaw_data_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_flaw_data_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class ExploitsApiV1FlawDataListResponse200(OSIDBModel):
         exploits_api_v1_flaw_data_list_response_200.additional_properties = d
         return exploits_api_v1_flaw_data_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawReportData"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_data_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_data_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class ExploitsApiV1ReportDataListResponse200(OSIDBModel):
         exploits_api_v1_report_data_list_response_200.additional_properties = d
         return exploits_api_v1_report_data_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["ExploitOnlyReportData"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -215,23 +216,9 @@ class ExploitsApiV1ReportDateRetrieveResponse200(OSIDBModel):
         exploits_api_v1_report_date_retrieve_response_200.additional_properties = d
         return exploits_api_v1_report_date_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "action_required": list[
-                "ExploitsApiV1ReportDateRetrieveResponse200ActionRequiredItem"
-            ],
-            "cutoff_date": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "evaluated_cves": int,
-            "no_action": list["ExploitsApiV1ReportDateRetrieveResponse200NoActionItem"],
-            "not_relevant": list[
-                "ExploitsApiV1ReportDateRetrieveResponse200NotRelevantItem"
-            ],
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_action_required_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_action_required_item.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -28,9 +29,9 @@ class ExploitsApiV1ReportDateRetrieveResponse200ActionRequiredItem(OSIDBModel):
         exploits_api_v1_report_date_retrieve_response_200_action_required_item.additional_properties = d
         return exploits_api_v1_report_date_retrieve_response_200_action_required_item
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_no_action_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_no_action_item.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -28,9 +29,9 @@ class ExploitsApiV1ReportDateRetrieveResponse200NoActionItem(OSIDBModel):
         exploits_api_v1_report_date_retrieve_response_200_no_action_item.additional_properties = d
         return exploits_api_v1_report_date_retrieve_response_200_no_action_item
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_not_relevant_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_not_relevant_item.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -28,9 +29,9 @@ class ExploitsApiV1ReportDateRetrieveResponse200NotRelevantItem(OSIDBModel):
         exploits_api_v1_report_date_retrieve_response_200_not_relevant_item.additional_properties = d
         return exploits_api_v1_report_date_retrieve_response_200_not_relevant_item
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -129,18 +130,9 @@ class ExploitsApiV1ReportExplanationsRetrieveResponse200(OSIDBModel):
         exploits_api_v1_report_explanations_retrieve_response_200.additional_properties = d
         return exploits_api_v1_report_explanations_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "explanations": list[
-                "ExploitsApiV1ReportExplanationsRetrieveResponse200ExplanationsItem"
-            ],
-            "page_size": int,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200_explanations_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200_explanations_item.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -34,9 +35,9 @@ class ExploitsApiV1ReportExplanationsRetrieveResponse200ExplanationsItem(OSIDBMo
             exploits_api_v1_report_explanations_retrieve_response_200_explanations_item
         )
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -128,18 +129,9 @@ class ExploitsApiV1ReportPendingRetrieveResponse200(OSIDBModel):
         exploits_api_v1_report_pending_retrieve_response_200.additional_properties = d
         return exploits_api_v1_report_pending_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "pending_actions": list[
-                "ExploitsApiV1ReportPendingRetrieveResponse200PendingActionsItem"
-            ],
-            "pending_actions_count": int,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200_pending_actions_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200_pending_actions_item.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -32,9 +33,9 @@ class ExploitsApiV1ReportPendingRetrieveResponse200PendingActionsItem(OSIDBModel
         exploits_api_v1_report_pending_retrieve_response_200_pending_actions_item.additional_properties = d
         return exploits_api_v1_report_pending_retrieve_response_200_pending_actions_item
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_status_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -103,17 +104,9 @@ class ExploitsApiV1StatusRetrieveResponse200(OSIDBModel):
         exploits_api_v1_status_retrieve_response_200.additional_properties = d
         return exploits_api_v1_status_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "exploits_count": int,
-            "exploits_count_relevant": int,
-            "last_exploit": int,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_supported_products_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_supported_products_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class ExploitsApiV1SupportedProductsListResponse200(OSIDBModel):
         exploits_api_v1_supported_products_list_response_200.additional_properties = d
         return exploits_api_v1_supported_products_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["SupportedProducts"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw.py
+++ b/osidb_bindings/bindings/python_client/models/flaw.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -893,44 +894,9 @@ class Flaw(OSIDBModel):
         flaw.additional_properties = d
         return flaw
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "title": str,
-            "trackers": list[str],
-            "comment_zero": str,
-            "affects": list["Affect"],
-            "comments": list["Comment"],
-            "package_versions": list["Package"],
-            "acknowledgments": list["FlawAcknowledgment"],
-            "references": list["FlawReference"],
-            "cvss_scores": list["FlawCVSS"],
-            "labels": list["FlawCollaborator"],
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "classification": FlawClassification,
-            "task_key": Union[None, str],
-            "alerts": list["Alert"],
-            "cve_id": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "components": list[str],
-            "cve_description": str,
-            "requires_cve_description": Union[BlankEnum, RequiresCveDescriptionEnum],
-            "statement": str,
-            "cwe_id": str,
-            "unembargo_dt": Union[None, datetime.datetime],
-            "source": Union[BlankEnum, SourceBe0Enum],
-            "reported_dt": Union[None, datetime.datetime],
-            "mitigation": str,
-            "major_incident_state": Union[BlankEnum, MajorIncidentStateEnum],
-            "major_incident_start_dt": Union[None, datetime.datetime],
-            "nist_cvss_validation": Union[BlankEnum, NistCvssValidationEnum],
-            "group_key": str,
-            "owner": str,
-            "team_id": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -170,19 +171,9 @@ class FlawAcknowledgment(OSIDBModel):
         flaw_acknowledgment.additional_properties = d
         return flaw_acknowledgment
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "affiliation": str,
-            "from_upstream": bool,
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -93,14 +94,9 @@ class FlawAcknowledgmentPostRequest(OSIDBModel):
         flaw_acknowledgment_post_request.additional_properties = d
         return flaw_acknowledgment_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "affiliation": str,
-            "from_upstream": bool,
-            "embargoed": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put_request.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -118,15 +119,9 @@ class FlawAcknowledgmentPutRequest(OSIDBModel):
         flaw_acknowledgment_put_request.additional_properties = d
         return flaw_acknowledgment_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "affiliation": str,
-            "from_upstream": bool,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_request.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -105,16 +106,9 @@ class FlawAcknowledgmentRequest(OSIDBModel):
         flaw_acknowledgment_request.additional_properties = d
         return flaw_acknowledgment_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "affiliation": str,
-            "from_upstream": bool,
-            "flaw": UUID,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_classification.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_classification.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.flaw_classification_state import FlawClassificationState
 from ..types import UNSET, OSIDBModel, Unset
@@ -57,12 +58,9 @@ class FlawClassification(OSIDBModel):
         flaw_classification.additional_properties = d
         return flaw_classification
 
-    @staticmethod
-    def get_fields():
-        return {
-            "workflow": str,
-            "state": FlawClassificationState,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_collaborator.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_collaborator.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.state_enum import StateEnum
 from ..types import UNSET, OSIDBModel, Unset
@@ -102,16 +103,9 @@ class FlawCollaborator(OSIDBModel):
         flaw_collaborator.additional_properties = d
         return flaw_collaborator
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "label": str,
-            "type": str,
-            "state": StateEnum,
-            "contributor": str,
-            "relevant": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_collaborator_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_collaborator_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.state_enum import StateEnum
 from ..types import UNSET, OSIDBModel, Unset
@@ -93,13 +94,9 @@ class FlawCollaboratorPostRequest(OSIDBModel):
         flaw_collaborator_post_request.additional_properties = d
         return flaw_collaborator_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "label": str,
-            "state": StateEnum,
-            "contributor": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_collaborator_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_collaborator_request.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.state_enum import StateEnum
 from ..types import UNSET, OSIDBModel, Unset
@@ -93,15 +94,9 @@ class FlawCollaboratorRequest(OSIDBModel):
         flaw_collaborator_request.additional_properties = d
         return flaw_collaborator_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "label": str,
-            "state": StateEnum,
-            "contributor": str,
-            "relevant": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_comment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -188,21 +189,9 @@ class FlawComment(OSIDBModel):
         flaw_comment.additional_properties = d
         return flaw_comment
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "text": str,
-            "uuid": UUID,
-            "external_system_id": str,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "embargoed": bool,
-            "order": int,
-            "creator": str,
-            "is_private": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_comment_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -101,14 +102,9 @@ class FlawCommentPostRequest(OSIDBModel):
         flaw_comment_post_request.additional_properties = d
         return flaw_comment_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "text": str,
-            "embargoed": bool,
-            "creator": str,
-            "is_private": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -215,21 +216,9 @@ class FlawCVSS(OSIDBModel):
         flaw_cvss.additional_properties = d
         return flaw_cvss
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.cvss_version_enum import CvssVersionEnum
 from ..models.issuer_enum import IssuerEnum
@@ -144,15 +145,9 @@ class FlawCVSSPostRequest(OSIDBModel):
         flaw_cvss_post_request.additional_properties = d
         return flaw_cvss_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_put_request.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -169,16 +170,9 @@ class FlawCVSSPutRequest(OSIDBModel):
         flaw_cvss_put_request.additional_properties = d
         return flaw_cvss_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_request.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -141,17 +142,9 @@ class FlawCVSSRequest(OSIDBModel):
         flaw_cvss_request.additional_properties = d
         return flaw_cvss_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_cvssv2.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvssv2.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -215,21 +216,9 @@ class FlawCVSSV2(OSIDBModel):
         flaw_cvssv2.additional_properties = d
         return flaw_cvssv2
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_cvssv2_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvssv2_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.cvss_version_enum import CvssVersionEnum
 from ..types import UNSET, OSIDBModel, Unset
@@ -121,14 +122,9 @@ class FlawCVSSV2PostRequest(OSIDBModel):
         flaw_cvssv2_post_request.additional_properties = d
         return flaw_cvssv2_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "comment": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_cvssv2_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvssv2_put_request.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -146,15 +147,9 @@ class FlawCVSSV2PutRequest(OSIDBModel):
         flaw_cvssv2_put_request.additional_properties = d
         return flaw_cvssv2_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "vector": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "comment": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_label.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_label.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -50,12 +51,9 @@ class FlawLabel(OSIDBModel):
         flaw_label.additional_properties = d
         return flaw_label
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "type": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -152,17 +153,9 @@ class FlawPackageVersion(OSIDBModel):
         flaw_package_version.additional_properties = d
         return flaw_package_version
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["FlawVersion"],
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version_post_request.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -114,13 +115,9 @@ class FlawPackageVersionPostRequest(OSIDBModel):
         flaw_package_version_post_request.additional_properties = d
         return flaw_package_version_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["FlawVersionRequest"],
-            "embargoed": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version_put_request.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -139,14 +140,9 @@ class FlawPackageVersionPutRequest(OSIDBModel):
         flaw_package_version_put_request.additional_properties = d
         return flaw_package_version_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["FlawVersionRequest"],
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_post_request.py
@@ -4,6 +4,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -800,30 +801,9 @@ class FlawPostRequest(OSIDBModel):
         flaw_post_request.additional_properties = d
         return flaw_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "title": str,
-            "comment_zero": str,
-            "embargoed": bool,
-            "cve_id": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "components": list[str],
-            "cve_description": str,
-            "requires_cve_description": Union[BlankEnum, RequiresCveDescriptionEnum],
-            "statement": str,
-            "cwe_id": str,
-            "unembargo_dt": Union[None, datetime.datetime],
-            "source": Union[BlankEnum, SourceBe0Enum],
-            "reported_dt": Union[None, datetime.datetime],
-            "mitigation": str,
-            "major_incident_state": Union[BlankEnum, MajorIncidentStateEnum],
-            "major_incident_start_dt": Union[None, datetime.datetime],
-            "nist_cvss_validation": Union[BlankEnum, NistCvssValidationEnum],
-            "group_key": str,
-            "owner": str,
-            "team_id": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_reference.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.flaw_reference_type import FlawReferenceType
@@ -178,19 +179,9 @@ class FlawReference(OSIDBModel):
         flaw_reference.additional_properties = d
         return flaw_reference
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "url": str,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "description": str,
-            "type": FlawReferenceType,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_post_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.flaw_reference_type import FlawReferenceType
 from ..types import UNSET, OSIDBModel, Unset
@@ -107,14 +108,9 @@ class FlawReferencePostRequest(OSIDBModel):
         flaw_reference_post_request.additional_properties = d
         return flaw_reference_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "url": str,
-            "embargoed": bool,
-            "description": str,
-            "type": FlawReferenceType,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_put_request.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.flaw_reference_type import FlawReferenceType
@@ -132,15 +133,9 @@ class FlawReferencePutRequest(OSIDBModel):
         flaw_reference_put_request.additional_properties = d
         return flaw_reference_put_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "url": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "description": str,
-            "type": FlawReferenceType,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_request.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.flaw_reference_type import FlawReferenceType
@@ -113,16 +114,9 @@ class FlawReferenceRequest(OSIDBModel):
         flaw_reference_request.additional_properties = d
         return flaw_reference_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "url": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "description": str,
-            "type": FlawReferenceType,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_report_data.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -85,12 +86,9 @@ class FlawReportData(OSIDBModel):
         flaw_report_data.additional_properties = d
         return flaw_report_data
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve_id": Union[None, str],
-            "affects": list["AffectReportData"],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_request.py
@@ -4,6 +4,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -823,31 +824,9 @@ class FlawRequest(OSIDBModel):
         flaw_request.additional_properties = d
         return flaw_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "title": str,
-            "comment_zero": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "cve_id": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "components": list[str],
-            "cve_description": str,
-            "requires_cve_description": Union[BlankEnum, RequiresCveDescriptionEnum],
-            "statement": str,
-            "cwe_id": str,
-            "unembargo_dt": Union[None, datetime.datetime],
-            "source": Union[BlankEnum, SourceBe0Enum],
-            "reported_dt": Union[None, datetime.datetime],
-            "mitigation": str,
-            "major_incident_state": Union[BlankEnum, MajorIncidentStateEnum],
-            "major_incident_start_dt": Union[None, datetime.datetime],
-            "nist_cvss_validation": Union[BlankEnum, NistCvssValidationEnum],
-            "group_key": str,
-            "owner": str,
-            "team_id": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_uuid_list_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_uuid_list_request.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -89,11 +90,9 @@ class FlawUUIDListRequest(OSIDBModel):
         flaw_uuid_list_request.additional_properties = d
         return flaw_uuid_list_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw_uuids": list[UUID],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_version.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_version.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -41,11 +42,9 @@ class FlawVersion(OSIDBModel):
         flaw_version.additional_properties = d
         return flaw_version
 
-    @staticmethod
-    def get_fields():
-        return {
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/flaw_version_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_version_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -41,11 +42,9 @@ class FlawVersionRequest(OSIDBModel):
         flaw_version_request.additional_properties = d
         return flaw_version_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/integration_token_get.py
+++ b/osidb_bindings/bindings/python_client/models/integration_token_get.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -70,12 +71,9 @@ class IntegrationTokenGet(OSIDBModel):
         integration_token_get.additional_properties = d
         return integration_token_get
 
-    @staticmethod
-    def get_fields():
-        return {
-            "jira": Union[None, str],
-            "bugzilla": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/module_component.py
+++ b/osidb_bindings/bindings/python_client/models/module_component.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -109,15 +110,9 @@ class ModuleComponent(OSIDBModel):
         module_component.additional_properties = d
         return module_component
 
-    @staticmethod
-    def get_fields():
-        return {
-            "ps_module": str,
-            "ps_component": str,
-            "streams": list["PsStreamSelection"],
-            "selected": bool,
-            "affect": Affect,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_bulk_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_bulk_create_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -109,15 +110,9 @@ class OsidbApiV1AffectsBulkCreateResponse200(OSIDBModel):
         osidb_api_v1_affects_bulk_create_response_200.additional_properties = d
         return osidb_api_v1_affects_bulk_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "results": list["Affect"],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_bulk_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_bulk_destroy_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1AffectsBulkDestroyResponse200(OSIDBModel):
         osidb_api_v1_affects_bulk_destroy_response_200.additional_properties = d
         return osidb_api_v1_affects_bulk_destroy_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_bulk_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_bulk_update_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -109,15 +110,9 @@ class OsidbApiV1AffectsBulkUpdateResponse200(OSIDBModel):
         osidb_api_v1_affects_bulk_update_response_200.additional_properties = d
         return osidb_api_v1_affects_bulk_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "results": list["Affect"],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.affectedness_enum import AffectednessEnum
@@ -613,36 +614,9 @@ class OsidbApiV1AffectsCreateResponse201(OSIDBModel):
         osidb_api_v1_affects_create_response_201.additional_properties = d
         return osidb_api_v1_affects_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "flaw": Union[None, UUID],
-            "ps_module": str,
-            "cve_id": str,
-            "ps_product": str,
-            "trackers": list["Tracker"],
-            "delegated_resolution": str,
-            "cvss_scores": list["AffectCVSS"],
-            "delegated_not_affected_justification": str,
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "ps_component": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "purl": Union[None, str],
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV1AffectsCvssScoresCreateResponse201(OSIDBModel):
         osidb_api_v1_affects_cvss_scores_create_response_201.additional_properties = d
         return osidb_api_v1_affects_cvss_scores_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_destroy_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1AffectsCvssScoresDestroyResponse200(OSIDBModel):
         osidb_api_v1_affects_cvss_scores_destroy_response_200.additional_properties = d
         return osidb_api_v1_affects_cvss_scores_destroy_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1AffectsCvssScoresListResponse200(OSIDBModel):
         osidb_api_v1_affects_cvss_scores_list_response_200.additional_properties = d
         return osidb_api_v1_affects_cvss_scores_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["AffectCVSS"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV1AffectsCvssScoresRetrieveResponse200(OSIDBModel):
         osidb_api_v1_affects_cvss_scores_retrieve_response_200.additional_properties = d
         return osidb_api_v1_affects_cvss_scores_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV1AffectsCvssScoresUpdateResponse200(OSIDBModel):
         osidb_api_v1_affects_cvss_scores_update_response_200.additional_properties = d
         return osidb_api_v1_affects_cvss_scores_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_destroy_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1AffectsDestroyResponse200(OSIDBModel):
         osidb_api_v1_affects_destroy_response_200.additional_properties = d
         return osidb_api_v1_affects_destroy_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1AffectsListResponse200(OSIDBModel):
         osidb_api_v1_affects_list_response_200.additional_properties = d
         return osidb_api_v1_affects_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Affect"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.affectedness_enum import AffectednessEnum
@@ -613,36 +614,9 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_affects_retrieve_response_200.additional_properties = d
         return osidb_api_v1_affects_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "flaw": Union[None, UUID],
-            "ps_module": str,
-            "cve_id": str,
-            "ps_product": str,
-            "trackers": list["Tracker"],
-            "delegated_resolution": str,
-            "cvss_scores": list["AffectCVSS"],
-            "delegated_not_affected_justification": str,
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "ps_component": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "purl": Union[None, str],
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.affectedness_enum import AffectednessEnum
@@ -613,36 +614,9 @@ class OsidbApiV1AffectsUpdateResponse200(OSIDBModel):
         osidb_api_v1_affects_update_response_200.additional_properties = d
         return osidb_api_v1_affects_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "flaw": Union[None, UUID],
-            "ps_module": str,
-            "cve_id": str,
-            "ps_product": str,
-            "trackers": list["Tracker"],
-            "delegated_resolution": str,
-            "cvss_scores": list["AffectCVSS"],
-            "delegated_not_affected_justification": str,
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affectedness": Union[AffectednessEnum, BlankEnum],
-            "resolution": Union[BlankEnum, ResolutionEnum],
-            "ps_component": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "purl": Union[None, str],
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1AlertsListResponse200(OSIDBModel):
         osidb_api_v1_alerts_list_response_200.additional_properties = d
         return osidb_api_v1_alerts_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Alert"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.alert_type_enum import AlertTypeEnum
@@ -164,21 +165,9 @@ class OsidbApiV1AlertsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_alerts_retrieve_response_200.additional_properties = d
         return osidb_api_v1_alerts_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "name": str,
-            "description": str,
-            "parent_uuid": UUID,
-            "parent_model": str,
-            "alert_type": AlertTypeEnum,
-            "resolution_steps": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1AuditListResponse200(OSIDBModel):
         osidb_api_v1_audit_list_response_200.additional_properties = d
         return osidb_api_v1_audit_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Audit"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -166,22 +167,9 @@ class OsidbApiV1AuditRetrieveResponse200(OSIDBModel):
         osidb_api_v1_audit_retrieve_response_200.additional_properties = d
         return osidb_api_v1_audit_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "pgh_created_at": datetime.datetime,
-            "pgh_slug": str,
-            "pgh_obj_model": str,
-            "pgh_label": str,
-            "pgh_diff": Any,
-            "pgh_data": str,
-            "pgh_obj_id": Union[None, str],
-            "pgh_context": Any,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_update_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -166,22 +167,9 @@ class OsidbApiV1AuditUpdateResponse200(OSIDBModel):
         osidb_api_v1_audit_update_response_200.additional_properties = d
         return osidb_api_v1_audit_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "pgh_created_at": datetime.datetime,
-            "pgh_slug": str,
-            "pgh_obj_model": str,
-            "pgh_label": str,
-            "pgh_diff": Any,
-            "pgh_data": str,
-            "pgh_obj_id": Union[None, str],
-            "pgh_context": Any,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_204.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1AvailableFlawsRetrieveResponse204(OSIDBModel):
         osidb_api_v1_available_flaws_retrieve_response_204.additional_properties = d
         return osidb_api_v1_available_flaws_retrieve_response_204
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_400.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_400.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1AvailableFlawsRetrieveResponse400(OSIDBModel):
         osidb_api_v1_available_flaws_retrieve_response_400.additional_properties = d
         return osidb_api_v1_available_flaws_retrieve_response_400
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_404.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_404.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1AvailableFlawsRetrieveResponse404(OSIDBModel):
         osidb_api_v1_available_flaws_retrieve_response_404.additional_properties = d
         return osidb_api_v1_available_flaws_retrieve_response_404
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -212,23 +213,9 @@ class OsidbApiV1FlawsAcknowledgmentsCreateResponse201(OSIDBModel):
         osidb_api_v1_flaws_acknowledgments_create_response_201.additional_properties = d
         return osidb_api_v1_flaws_acknowledgments_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "affiliation": str,
-            "from_upstream": bool,
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_destroy_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1FlawsAcknowledgmentsDestroyResponse200(OSIDBModel):
         osidb_api_v1_flaws_acknowledgments_destroy_response_200.additional_properties = d
         return osidb_api_v1_flaws_acknowledgments_destroy_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1FlawsAcknowledgmentsListResponse200(OSIDBModel):
         osidb_api_v1_flaws_acknowledgments_list_response_200.additional_properties = d
         return osidb_api_v1_flaws_acknowledgments_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawAcknowledgment"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -212,23 +213,9 @@ class OsidbApiV1FlawsAcknowledgmentsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_flaws_acknowledgments_retrieve_response_200.additional_properties = d
         return osidb_api_v1_flaws_acknowledgments_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "affiliation": str,
-            "from_upstream": bool,
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -212,23 +213,9 @@ class OsidbApiV1FlawsAcknowledgmentsUpdateResponse200(OSIDBModel):
         osidb_api_v1_flaws_acknowledgments_update_response_200.additional_properties = d
         return osidb_api_v1_flaws_acknowledgments_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "affiliation": str,
-            "from_upstream": bool,
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -230,25 +231,9 @@ class OsidbApiV1FlawsCommentsCreateResponse201(OSIDBModel):
         osidb_api_v1_flaws_comments_create_response_201.additional_properties = d
         return osidb_api_v1_flaws_comments_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "text": str,
-            "uuid": UUID,
-            "external_system_id": str,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "embargoed": bool,
-            "order": int,
-            "creator": str,
-            "is_private": bool,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1FlawsCommentsListResponse200(OSIDBModel):
         osidb_api_v1_flaws_comments_list_response_200.additional_properties = d
         return osidb_api_v1_flaws_comments_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawComment"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -230,25 +231,9 @@ class OsidbApiV1FlawsCommentsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_flaws_comments_retrieve_response_200.additional_properties = d
         return osidb_api_v1_flaws_comments_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "text": str,
-            "uuid": UUID,
-            "external_system_id": str,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "embargoed": bool,
-            "order": int,
-            "creator": str,
-            "is_private": bool,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -935,48 +936,9 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
         osidb_api_v1_flaws_create_response_201.additional_properties = d
         return osidb_api_v1_flaws_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "title": str,
-            "trackers": list[str],
-            "comment_zero": str,
-            "affects": list["Affect"],
-            "comments": list["Comment"],
-            "package_versions": list["Package"],
-            "acknowledgments": list["FlawAcknowledgment"],
-            "references": list["FlawReference"],
-            "cvss_scores": list["FlawCVSS"],
-            "labels": list["FlawCollaborator"],
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "classification": FlawClassification,
-            "task_key": Union[None, str],
-            "alerts": list["Alert"],
-            "cve_id": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "components": list[str],
-            "cve_description": str,
-            "requires_cve_description": Union[BlankEnum, RequiresCveDescriptionEnum],
-            "statement": str,
-            "cwe_id": str,
-            "unembargo_dt": Union[None, datetime.datetime],
-            "source": Union[BlankEnum, SourceBe0Enum],
-            "reported_dt": Union[None, datetime.datetime],
-            "mitigation": str,
-            "major_incident_state": Union[BlankEnum, MajorIncidentStateEnum],
-            "major_incident_start_dt": Union[None, datetime.datetime],
-            "nist_cvss_validation": Union[BlankEnum, NistCvssValidationEnum],
-            "group_key": str,
-            "owner": str,
-            "team_id": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV1FlawsCvssScoresCreateResponse201(OSIDBModel):
         osidb_api_v1_flaws_cvss_scores_create_response_201.additional_properties = d
         return osidb_api_v1_flaws_cvss_scores_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_destroy_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1FlawsCvssScoresDestroyResponse200(OSIDBModel):
         osidb_api_v1_flaws_cvss_scores_destroy_response_200.additional_properties = d
         return osidb_api_v1_flaws_cvss_scores_destroy_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1FlawsCvssScoresListResponse200(OSIDBModel):
         osidb_api_v1_flaws_cvss_scores_list_response_200.additional_properties = d
         return osidb_api_v1_flaws_cvss_scores_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawCVSS"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV1FlawsCvssScoresRetrieveResponse200(OSIDBModel):
         osidb_api_v1_flaws_cvss_scores_retrieve_response_200.additional_properties = d
         return osidb_api_v1_flaws_cvss_scores_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV1FlawsCvssScoresUpdateResponse200(OSIDBModel):
         osidb_api_v1_flaws_cvss_scores_update_response_200.additional_properties = d
         return osidb_api_v1_flaws_cvss_scores_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "issuer": IssuerEnum,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.state_enum import StateEnum
@@ -146,20 +147,9 @@ class OsidbApiV1FlawsLabelsCreateResponse201(OSIDBModel):
         osidb_api_v1_flaws_labels_create_response_201.additional_properties = d
         return osidb_api_v1_flaws_labels_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "label": str,
-            "type": str,
-            "state": StateEnum,
-            "contributor": str,
-            "relevant": bool,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_destroy_response_204.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1FlawsLabelsDestroyResponse204(OSIDBModel):
         osidb_api_v1_flaws_labels_destroy_response_204.additional_properties = d
         return osidb_api_v1_flaws_labels_destroy_response_204
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1FlawsLabelsListResponse200(OSIDBModel):
         osidb_api_v1_flaws_labels_list_response_200.additional_properties = d
         return osidb_api_v1_flaws_labels_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawCollaborator"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.state_enum import StateEnum
@@ -146,20 +147,9 @@ class OsidbApiV1FlawsLabelsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_flaws_labels_retrieve_response_200.additional_properties = d
         return osidb_api_v1_flaws_labels_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "label": str,
-            "type": str,
-            "state": StateEnum,
-            "contributor": str,
-            "relevant": bool,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.state_enum import StateEnum
@@ -146,20 +147,9 @@ class OsidbApiV1FlawsLabelsUpdateResponse200(OSIDBModel):
         osidb_api_v1_flaws_labels_update_response_200.additional_properties = d
         return osidb_api_v1_flaws_labels_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "label": str,
-            "type": str,
-            "state": StateEnum,
-            "contributor": str,
-            "relevant": bool,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1FlawsListResponse200(OSIDBModel):
         osidb_api_v1_flaws_list_response_200.additional_properties = d
         return osidb_api_v1_flaws_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Flaw"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -194,21 +195,9 @@ class OsidbApiV1FlawsPackageVersionsCreateResponse201(OSIDBModel):
         osidb_api_v1_flaws_package_versions_create_response_201.additional_properties = d
         return osidb_api_v1_flaws_package_versions_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["FlawVersion"],
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_destroy_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1FlawsPackageVersionsDestroyResponse200(OSIDBModel):
         osidb_api_v1_flaws_package_versions_destroy_response_200.additional_properties = d
         return osidb_api_v1_flaws_package_versions_destroy_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1FlawsPackageVersionsListResponse200(OSIDBModel):
         osidb_api_v1_flaws_package_versions_list_response_200.additional_properties = d
         return osidb_api_v1_flaws_package_versions_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawPackageVersion"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -194,21 +195,9 @@ class OsidbApiV1FlawsPackageVersionsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_flaws_package_versions_retrieve_response_200.additional_properties = d
         return osidb_api_v1_flaws_package_versions_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["FlawVersion"],
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -194,21 +195,9 @@ class OsidbApiV1FlawsPackageVersionsUpdateResponse200(OSIDBModel):
         osidb_api_v1_flaws_package_versions_update_response_200.additional_properties = d
         return osidb_api_v1_flaws_package_versions_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["FlawVersion"],
-            "flaw": UUID,
-            "uuid": UUID,
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_promote_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_promote_create_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1FlawsPromoteCreateResponse200(OSIDBModel):
         osidb_api_v1_flaws_promote_create_response_200.additional_properties = d
         return osidb_api_v1_flaws_promote_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.flaw_reference_type import FlawReferenceType
@@ -220,23 +221,9 @@ class OsidbApiV1FlawsReferencesCreateResponse201(OSIDBModel):
         osidb_api_v1_flaws_references_create_response_201.additional_properties = d
         return osidb_api_v1_flaws_references_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "url": str,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "description": str,
-            "type": FlawReferenceType,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_destroy_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1FlawsReferencesDestroyResponse200(OSIDBModel):
         osidb_api_v1_flaws_references_destroy_response_200.additional_properties = d
         return osidb_api_v1_flaws_references_destroy_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1FlawsReferencesListResponse200(OSIDBModel):
         osidb_api_v1_flaws_references_list_response_200.additional_properties = d
         return osidb_api_v1_flaws_references_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawReference"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.flaw_reference_type import FlawReferenceType
@@ -220,23 +221,9 @@ class OsidbApiV1FlawsReferencesRetrieveResponse200(OSIDBModel):
         osidb_api_v1_flaws_references_retrieve_response_200.additional_properties = d
         return osidb_api_v1_flaws_references_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "url": str,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "description": str,
-            "type": FlawReferenceType,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.flaw_reference_type import FlawReferenceType
@@ -220,23 +221,9 @@ class OsidbApiV1FlawsReferencesUpdateResponse200(OSIDBModel):
         osidb_api_v1_flaws_references_update_response_200.additional_properties = d
         return osidb_api_v1_flaws_references_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw": UUID,
-            "url": str,
-            "uuid": UUID,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "description": str,
-            "type": FlawReferenceType,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_reject_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_reject_create_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1FlawsRejectCreateResponse200(OSIDBModel):
         osidb_api_v1_flaws_reject_create_response_200.additional_properties = d
         return osidb_api_v1_flaws_reject_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -935,48 +936,9 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_flaws_retrieve_response_200.additional_properties = d
         return osidb_api_v1_flaws_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "title": str,
-            "trackers": list[str],
-            "comment_zero": str,
-            "affects": list["Affect"],
-            "comments": list["Comment"],
-            "package_versions": list["Package"],
-            "acknowledgments": list["FlawAcknowledgment"],
-            "references": list["FlawReference"],
-            "cvss_scores": list["FlawCVSS"],
-            "labels": list["FlawCollaborator"],
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "classification": FlawClassification,
-            "task_key": Union[None, str],
-            "alerts": list["Alert"],
-            "cve_id": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "components": list[str],
-            "cve_description": str,
-            "requires_cve_description": Union[BlankEnum, RequiresCveDescriptionEnum],
-            "statement": str,
-            "cwe_id": str,
-            "unembargo_dt": Union[None, datetime.datetime],
-            "source": Union[BlankEnum, SourceBe0Enum],
-            "reported_dt": Union[None, datetime.datetime],
-            "mitigation": str,
-            "major_incident_state": Union[BlankEnum, MajorIncidentStateEnum],
-            "major_incident_start_dt": Union[None, datetime.datetime],
-            "nist_cvss_validation": Union[BlankEnum, NistCvssValidationEnum],
-            "group_key": str,
-            "owner": str,
-            "team_id": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -935,48 +936,9 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
         osidb_api_v1_flaws_update_response_200.additional_properties = d
         return osidb_api_v1_flaws_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "uuid": UUID,
-            "title": str,
-            "trackers": list[str],
-            "comment_zero": str,
-            "affects": list["Affect"],
-            "comments": list["Comment"],
-            "package_versions": list["Package"],
-            "acknowledgments": list["FlawAcknowledgment"],
-            "references": list["FlawReference"],
-            "cvss_scores": list["FlawCVSS"],
-            "labels": list["FlawCollaborator"],
-            "embargoed": bool,
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "classification": FlawClassification,
-            "task_key": Union[None, str],
-            "alerts": list["Alert"],
-            "cve_id": Union[None, str],
-            "impact": Union[BlankEnum, ImpactEnum],
-            "components": list[str],
-            "cve_description": str,
-            "requires_cve_description": Union[BlankEnum, RequiresCveDescriptionEnum],
-            "statement": str,
-            "cwe_id": str,
-            "unembargo_dt": Union[None, datetime.datetime],
-            "source": Union[BlankEnum, SourceBe0Enum],
-            "reported_dt": Union[None, datetime.datetime],
-            "mitigation": str,
-            "major_incident_state": Union[BlankEnum, MajorIncidentStateEnum],
-            "major_incident_start_dt": Union[None, datetime.datetime],
-            "nist_cvss_validation": Union[BlankEnum, NistCvssValidationEnum],
-            "group_key": str,
-            "owner": str,
-            "team_id": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1LabelsListResponse200(OSIDBModel):
         osidb_api_v1_labels_list_response_200.additional_properties = d
         return osidb_api_v1_labels_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawLabel"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -94,16 +95,9 @@ class OsidbApiV1LabelsRetrieveResponse200(OSIDBModel):
         osidb_api_v1_labels_retrieve_response_200.additional_properties = d
         return osidb_api_v1_labels_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-            "type": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_manifest_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_manifest_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV1ManifestRetrieveResponse200(OSIDBModel):
         osidb_api_v1_manifest_retrieve_response_200.additional_properties = d
         return osidb_api_v1_manifest_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_schema_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_schema_retrieve_response_200.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -28,9 +29,9 @@ class OsidbApiV1SchemaRetrieveResponse200(OSIDBModel):
         osidb_api_v1_schema_retrieve_response_200.additional_properties = d
         return osidb_api_v1_schema_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -130,16 +131,9 @@ class OsidbApiV1StatusRetrieveResponse200(OSIDBModel):
         osidb_api_v1_status_retrieve_response_200.additional_properties = d
         return osidb_api_v1_status_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "osidb_data": OsidbApiV1StatusRetrieveResponse200OsidbData,
-            "osidb_service": OsidbApiV1StatusRetrieveResponse200OsidbService,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_data.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_data.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -40,11 +41,9 @@ class OsidbApiV1StatusRetrieveResponse200OsidbData(OSIDBModel):
         osidb_api_v1_status_retrieve_response_200_osidb_data.additional_properties = d
         return osidb_api_v1_status_retrieve_response_200_osidb_data
 
-    @staticmethod
-    def get_fields():
-        return {
-            "flaw_count": int,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_service.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_service.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import OSIDBModel
 
@@ -28,9 +29,9 @@ class OsidbApiV1StatusRetrieveResponse200OsidbService(OSIDBModel):
         osidb_api_v1_status_retrieve_response_200_osidb_service.additional_properties = d
         return osidb_api_v1_status_retrieve_response_200_osidb_service
 
-    @staticmethod
-    def get_fields():
-        return {}
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -413,31 +414,9 @@ class OsidbApiV1TrackersCreateResponse201(OSIDBModel):
         osidb_api_v1_trackers_create_response_201.additional_properties = d
         return osidb_api_v1_trackers_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve_id": str,
-            "errata": list["Erratum"],
-            "ps_update_stream": str,
-            "status": str,
-            "resolution": str,
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "type": TrackerType,
-            "uuid": UUID,
-            "special_handling": list[SpecialHandlingEnum],
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affects": list[UUID],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV1TrackersListResponse200(OSIDBModel):
         osidb_api_v1_trackers_list_response_200.additional_properties = d
         return osidb_api_v1_trackers_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Tracker"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -422,32 +423,9 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
         osidb_api_v1_trackers_retrieve_response_200.additional_properties = d
         return osidb_api_v1_trackers_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve_id": str,
-            "errata": list["Erratum"],
-            "external_system_id": str,
-            "status": str,
-            "resolution": str,
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "type": TrackerType,
-            "uuid": UUID,
-            "special_handling": list[SpecialHandlingEnum],
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affects": list[UUID],
-            "ps_update_stream": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -422,32 +423,9 @@ class OsidbApiV1TrackersUpdateResponse200(OSIDBModel):
         osidb_api_v1_trackers_update_response_200.additional_properties = d
         return osidb_api_v1_trackers_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve_id": str,
-            "errata": list["Erratum"],
-            "external_system_id": str,
-            "status": str,
-            "resolution": str,
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "type": TrackerType,
-            "uuid": UUID,
-            "special_handling": list[SpecialHandlingEnum],
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affects": list[UUID],
-            "ps_update_stream": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV2BetaAffectsCvssScoresCreateResponse201(OSIDBModel):
         osidb_api_v2_beta_affects_cvss_scores_create_response_201.additional_properties = d
         return osidb_api_v2_beta_affects_cvss_scores_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_destroy_response_204.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV2BetaAffectsCvssScoresDestroyResponse204(OSIDBModel):
         osidb_api_v2_beta_affects_cvss_scores_destroy_response_204.additional_properties = d
         return osidb_api_v2_beta_affects_cvss_scores_destroy_response_204
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV2BetaAffectsCvssScoresListResponse200(OSIDBModel):
         osidb_api_v2_beta_affects_cvss_scores_list_response_200.additional_properties = d
         return osidb_api_v2_beta_affects_cvss_scores_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["AffectCVSSV2"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV2BetaAffectsCvssScoresRetrieveResponse200(OSIDBModel):
         osidb_api_v2_beta_affects_cvss_scores_retrieve_response_200.additional_properties = d
         return osidb_api_v2_beta_affects_cvss_scores_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_affects_cvss_scores_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV2BetaAffectsCvssScoresUpdateResponse200(OSIDBModel):
         osidb_api_v2_beta_affects_cvss_scores_update_response_200.additional_properties = d
         return osidb_api_v2_beta_affects_cvss_scores_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affect": UUID,
-            "comment": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_create_response_201.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV2BetaFlawsCvssScoresCreateResponse201(OSIDBModel):
         osidb_api_v2_beta_flaws_cvss_scores_create_response_201.additional_properties = d
         return osidb_api_v2_beta_flaws_cvss_scores_create_response_201
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_destroy_response_204.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbApiV2BetaFlawsCvssScoresDestroyResponse204(OSIDBModel):
         osidb_api_v2_beta_flaws_cvss_scores_destroy_response_204.additional_properties = d
         return osidb_api_v2_beta_flaws_cvss_scores_destroy_response_204
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_list_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -158,18 +159,9 @@ class OsidbApiV2BetaFlawsCvssScoresListResponse200(OSIDBModel):
         osidb_api_v2_beta_flaws_cvss_scores_list_response_200.additional_properties = d
         return osidb_api_v2_beta_flaws_cvss_scores_list_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawCVSSV2"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_retrieve_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV2BetaFlawsCvssScoresRetrieveResponse200(OSIDBModel):
         osidb_api_v2_beta_flaws_cvss_scores_retrieve_response_200.additional_properties = d
         return osidb_api_v2_beta_flaws_cvss_scores_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_beta_flaws_cvss_scores_update_response_200.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.cvss_version_enum import CvssVersionEnum
@@ -257,25 +258,9 @@ class OsidbApiV2BetaFlawsCvssScoresUpdateResponse200(OSIDBModel):
         osidb_api_v2_beta_flaws_cvss_scores_update_response_200.additional_properties = d
         return osidb_api_v2_beta_flaws_cvss_scores_update_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cvss_version": CvssVersionEnum,
-            "issuer": IssuerEnum,
-            "score": float,
-            "uuid": UUID,
-            "vector": str,
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "flaw": UUID,
-            "comment": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_healthy_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbHealthyRetrieveResponse200(OSIDBModel):
         osidb_healthy_retrieve_response_200.additional_properties = d
         return osidb_healthy_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_integrations_partial_update_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_integrations_partial_update_response_204.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class OsidbIntegrationsPartialUpdateResponse204(OSIDBModel):
         osidb_integrations_partial_update_response_204.additional_properties = d
         return osidb_integrations_partial_update_response_204
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_integrations_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_integrations_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -115,16 +116,9 @@ class OsidbIntegrationsRetrieveResponse200(OSIDBModel):
         osidb_integrations_retrieve_response_200.additional_properties = d
         return osidb_integrations_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "jira": Union[None, str],
-            "bugzilla": Union[None, str],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -127,18 +128,9 @@ class OsidbWhoamiRetrieveResponse200(OSIDBModel):
         osidb_whoami_retrieve_response_200.additional_properties = d
         return osidb_whoami_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "username": str,
-            "groups": list[str],
-            "profile": Profile,
-            "email": str,
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/package.py
+++ b/osidb_bindings/bindings/python_client/models/package.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -103,13 +104,9 @@ class Package(OSIDBModel):
         package.additional_properties = d
         return package
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["PackageVer"],
-            "alerts": list["Alert"],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/package_request.py
+++ b/osidb_bindings/bindings/python_client/models/package_request.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -74,12 +75,9 @@ class PackageRequest(OSIDBModel):
         package_request.additional_properties = d
         return package_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "package": str,
-            "versions": list["PackageVerRequest"],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/package_ver.py
+++ b/osidb_bindings/bindings/python_client/models/package_ver.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -51,12 +52,9 @@ class PackageVer(OSIDBModel):
         package_ver.additional_properties = d
         return package_ver
 
-    @staticmethod
-    def get_fields():
-        return {
-            "version": str,
-            "status": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/package_ver_request.py
+++ b/osidb_bindings/bindings/python_client/models/package_ver_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -42,11 +43,9 @@ class PackageVerRequest(OSIDBModel):
         package_ver_request.additional_properties = d
         return package_ver_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_cvss_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_cvss_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedAffectCVSSList(OSIDBModel):
         paginated_affect_cvss_list.additional_properties = d
         return paginated_affect_cvss_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["AffectCVSS"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_cvssv2_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_cvssv2_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedAffectCVSSV2List(OSIDBModel):
         paginated_affect_cvssv2_list.additional_properties = d
         return paginated_affect_cvssv2_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["AffectCVSSV2"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedAffectList(OSIDBModel):
         paginated_affect_list.additional_properties = d
         return paginated_affect_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Affect"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_alert_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_alert_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedAlertList(OSIDBModel):
         paginated_alert_list.additional_properties = d
         return paginated_alert_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Alert"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_audit_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_audit_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedAuditList(OSIDBModel):
         paginated_audit_list.additional_properties = d
         return paginated_audit_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Audit"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_epss_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_epss_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedEPSSList(OSIDBModel):
         paginated_epss_list.additional_properties = d
         return paginated_epss_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["EPSS"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_exploit_only_report_data_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_exploit_only_report_data_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedExploitOnlyReportDataList(OSIDBModel):
         paginated_exploit_only_report_data_list.additional_properties = d
         return paginated_exploit_only_report_data_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["ExploitOnlyReportData"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_acknowledgment_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_acknowledgment_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawAcknowledgmentList(OSIDBModel):
         paginated_flaw_acknowledgment_list.additional_properties = d
         return paginated_flaw_acknowledgment_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawAcknowledgment"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_collaborator_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_collaborator_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawCollaboratorList(OSIDBModel):
         paginated_flaw_collaborator_list.additional_properties = d
         return paginated_flaw_collaborator_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawCollaborator"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_comment_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_comment_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawCommentList(OSIDBModel):
         paginated_flaw_comment_list.additional_properties = d
         return paginated_flaw_comment_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawComment"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_cvss_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_cvss_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawCVSSList(OSIDBModel):
         paginated_flaw_cvss_list.additional_properties = d
         return paginated_flaw_cvss_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawCVSS"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_cvssv2_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_cvssv2_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawCVSSV2List(OSIDBModel):
         paginated_flaw_cvssv2_list.additional_properties = d
         return paginated_flaw_cvssv2_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawCVSSV2"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_label_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_label_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawLabelList(OSIDBModel):
         paginated_flaw_label_list.additional_properties = d
         return paginated_flaw_label_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawLabel"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawList(OSIDBModel):
         paginated_flaw_list.additional_properties = d
         return paginated_flaw_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Flaw"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_package_version_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_package_version_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawPackageVersionList(OSIDBModel):
         paginated_flaw_package_version_list.additional_properties = d
         return paginated_flaw_package_version_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawPackageVersion"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_reference_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_reference_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawReferenceList(OSIDBModel):
         paginated_flaw_reference_list.additional_properties = d
         return paginated_flaw_reference_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawReference"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_report_data_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_report_data_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedFlawReportDataList(OSIDBModel):
         paginated_flaw_report_data_list.additional_properties = d
         return paginated_flaw_report_data_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["FlawReportData"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_supported_products_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_supported_products_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedSupportedProductsList(OSIDBModel):
         paginated_supported_products_list.additional_properties = d
         return paginated_supported_products_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["SupportedProducts"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/paginated_tracker_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_tracker_list.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -113,14 +114,9 @@ class PaginatedTrackerList(OSIDBModel):
         paginated_tracker_list.additional_properties = d
         return paginated_tracker_list
 
-    @staticmethod
-    def get_fields():
-        return {
-            "count": int,
-            "results": list["Tracker"],
-            "next": Union[None, str],
-            "previous": Union[None, str],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/patched_integration_token_patch_request.py
+++ b/osidb_bindings/bindings/python_client/models/patched_integration_token_patch_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -73,12 +74,9 @@ class PatchedIntegrationTokenPatchRequest(OSIDBModel):
         patched_integration_token_patch_request.additional_properties = d
         return patched_integration_token_patch_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "jira": str,
-            "bugzilla": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/profile.py
+++ b/osidb_bindings/bindings/python_client/models/profile.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -49,12 +50,9 @@ class Profile(OSIDBModel):
         profile.additional_properties = d
         return profile
 
-    @staticmethod
-    def get_fields():
-        return {
-            "bz_user_id": str,
-            "jira_user_id": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/ps_stream_selection.py
+++ b/osidb_bindings/bindings/python_client/models/ps_stream_selection.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -76,15 +77,9 @@ class PsStreamSelection(OSIDBModel):
         ps_stream_selection.additional_properties = d
         return ps_stream_selection
 
-    @staticmethod
-    def get_fields():
-        return {
-            "ps_update_stream": str,
-            "selected": bool,
-            "acked": bool,
-            "eus": bool,
-            "aus": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/reject_request.py
+++ b/osidb_bindings/bindings/python_client/models/reject_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -53,11 +54,9 @@ class RejectRequest(OSIDBModel):
         reject_request.additional_properties = d
         return reject_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "reason": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/supported_products.py
+++ b/osidb_bindings/bindings/python_client/models/supported_products.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -40,11 +41,9 @@ class SupportedProducts(OSIDBModel):
         supported_products.additional_properties = d
         return supported_products
 
-    @staticmethod
-    def get_fields():
-        return {
-            "name": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/token_obtain_pair.py
+++ b/osidb_bindings/bindings/python_client/models/token_obtain_pair.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -49,12 +50,9 @@ class TokenObtainPair(OSIDBModel):
         token_obtain_pair.additional_properties = d
         return token_obtain_pair
 
-    @staticmethod
-    def get_fields():
-        return {
-            "access": str,
-            "refresh": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/token_obtain_pair_request.py
+++ b/osidb_bindings/bindings/python_client/models/token_obtain_pair_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -65,12 +66,9 @@ class TokenObtainPairRequest(OSIDBModel):
         token_obtain_pair_request.additional_properties = d
         return token_obtain_pair_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "username": str,
-            "password": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/token_refresh.py
+++ b/osidb_bindings/bindings/python_client/models/token_refresh.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -40,11 +41,9 @@ class TokenRefresh(OSIDBModel):
         token_refresh.additional_properties = d
         return token_refresh
 
-    @staticmethod
-    def get_fields():
-        return {
-            "access": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/token_refresh_request.py
+++ b/osidb_bindings/bindings/python_client/models/token_refresh_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -52,11 +53,9 @@ class TokenRefreshRequest(OSIDBModel):
         token_refresh_request.additional_properties = d
         return token_refresh_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "refresh": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/token_verify_request.py
+++ b/osidb_bindings/bindings/python_client/models/token_verify_request.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -52,11 +53,9 @@ class TokenVerifyRequest(OSIDBModel):
         token_verify_request.additional_properties = d
         return token_verify_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "token": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/tracker.py
+++ b/osidb_bindings/bindings/python_client/models/tracker.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -380,28 +381,9 @@ class Tracker(OSIDBModel):
         tracker.additional_properties = d
         return tracker
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve_id": str,
-            "errata": list["Erratum"],
-            "external_system_id": str,
-            "status": str,
-            "resolution": str,
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "type": TrackerType,
-            "uuid": UUID,
-            "special_handling": list[SpecialHandlingEnum],
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affects": list[UUID],
-            "ps_update_stream": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/tracker_post.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_post.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..models.blank_enum import BlankEnum
@@ -371,27 +372,9 @@ class TrackerPost(OSIDBModel):
         tracker_post.additional_properties = d
         return tracker_post
 
-    @staticmethod
-    def get_fields():
-        return {
-            "cve_id": str,
-            "errata": list["Erratum"],
-            "ps_update_stream": str,
-            "status": str,
-            "resolution": str,
-            "not_affected_justification": Union[
-                BlankEnum, NotAffectedJustificationEnum
-            ],
-            "type": TrackerType,
-            "uuid": UUID,
-            "special_handling": list[SpecialHandlingEnum],
-            "resolved_dt": Union[None, datetime.datetime],
-            "embargoed": bool,
-            "alerts": list["Alert"],
-            "created_dt": datetime.datetime,
-            "updated_dt": datetime.datetime,
-            "affects": list[UUID],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/tracker_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_post_request.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -157,15 +158,9 @@ class TrackerPostRequest(OSIDBModel):
         tracker_post_request.additional_properties = d
         return tracker_post_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "ps_update_stream": str,
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "affects": list[UUID],
-            "sync_to_bz": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/tracker_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_report_data.py
@@ -2,6 +2,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..models.tracker_type import TrackerType
 from ..types import UNSET, OSIDBModel, Unset
@@ -75,14 +76,9 @@ class TrackerReportData(OSIDBModel):
         tracker_report_data.additional_properties = d
         return tracker_report_data
 
-    @staticmethod
-    def get_fields():
-        return {
-            "type": TrackerType,
-            "external_system_id": str,
-            "status": str,
-            "resolution": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/tracker_request.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_request.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -161,15 +162,9 @@ class TrackerRequest(OSIDBModel):
         tracker_request.additional_properties = d
         return tracker_request
 
-    @staticmethod
-    def get_fields():
-        return {
-            "embargoed": bool,
-            "updated_dt": datetime.datetime,
-            "affects": list[UUID],
-            "ps_update_stream": str,
-            "sync_to_bz": bool,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/tracker_suggestion.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_suggestion.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -95,12 +96,9 @@ class TrackerSuggestion(OSIDBModel):
         tracker_suggestion.additional_properties = d
         return tracker_suggestion
 
-    @staticmethod
-    def get_fields():
-        return {
-            "modules_components": list["ModuleComponent"],
-            "not_applicable": list["Affect"],
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/trackers_api_v1_file_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/trackers_api_v1_file_create_response_200.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -140,16 +141,9 @@ class TrackersApiV1FileCreateResponse200(OSIDBModel):
         trackers_api_v1_file_create_response_200.additional_properties = d
         return trackers_api_v1_file_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "modules_components": list["ModuleComponent"],
-            "not_applicable": list["Affect"],
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/user.py
+++ b/osidb_bindings/bindings/python_client/models/user.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 
 from ..types import UNSET, OSIDBModel, Unset
 
@@ -82,14 +83,9 @@ class User(OSIDBModel):
         user.additional_properties = d
         return user
 
-    @staticmethod
-    def get_fields():
-        return {
-            "username": str,
-            "groups": list[str],
-            "profile": Profile,
-            "email": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_adjust_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_adjust_create_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class WorkflowsApiV1WorkflowsAdjustCreateResponse200(OSIDBModel):
         workflows_api_v1_workflows_adjust_create_response_200.additional_properties = d
         return workflows_api_v1_workflows_adjust_create_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_2_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_2_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class WorkflowsApiV1WorkflowsRetrieve2Response200(OSIDBModel):
         workflows_api_v1_workflows_retrieve_2_response_200.additional_properties = d
         return workflows_api_v1_workflows_retrieve_2_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class WorkflowsApiV1WorkflowsRetrieveResponse200(OSIDBModel):
         workflows_api_v1_workflows_retrieve_response_200.additional_properties = d
         return workflows_api_v1_workflows_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/workflows_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_healthy_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class WorkflowsHealthyRetrieveResponse200(OSIDBModel):
         workflows_healthy_retrieve_response_200.additional_properties = d
         return workflows_healthy_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/bindings/python_client/models/workflows_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_retrieve_response_200.py
@@ -3,6 +3,7 @@ from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 from dateutil.parser import isoparse
 
 from ..types import UNSET, OSIDBModel, Unset
@@ -76,14 +77,9 @@ class WorkflowsRetrieveResponse200(OSIDBModel):
         workflows_retrieve_response_200.additional_properties = d
         return workflows_retrieve_response_200
 
-    @staticmethod
-    def get_fields():
-        return {
-            "dt": datetime.datetime,
-            "env": str,
-            "revision": str,
-            "version": str,
-        }
+    @classmethod
+    def get_fields_new(cls):
+        return {f.name: f.type for f in _attrs_fields(cls)}
 
     @classmethod
     def new(cls):

--- a/osidb_bindings/templates_0.22.0/model.py.jinja
+++ b/osidb_bindings/templates_0.22.0/model.py.jinja
@@ -6,6 +6,7 @@ from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Unio
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from attrs import fields as _attrs_fields
 {% if model.is_multipart_body %}
 import json
 {% endif %}
@@ -195,14 +196,10 @@ return field_dict
 {% endif %}
         return {{ module_name }}
 
-    {# CHANGE START (3) - add new static method for fields obtain #}
-    @staticmethod
-    def get_fields():
-        return {
-            {% for property in model.required_properties + model.optional_properties %}
-            "{{ property.name }}": {{ property.get_type_string(no_optional=True) }},
-            {% endfor %}
-        }
+    {# CHANGE START (3) - add new class method for fields obtain #}
+    @classmethod
+    def get_fields(cls):
+        return {f.name : f.type for f in _attrs_fields(cls)}
     {# CHANGE END (3) #}
 
     {# CHANGE START (4) - add new classmethod for initializing empty model with Unset values  #}


### PR DESCRIPTION
This PR:
* changes `get_fields` method to get the available fields via attrs instead of listing them via jinja templates (that was broken because not all the types are imported all the times but only upon type checking)