### PR TITLE
Prevent Github API rate limits

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -9,6 +9,9 @@ The following dependencies are required for development and deployment:
 * python3 dependencies (see [pip-tools](#using-pip-tools))
 * tox
 
+### Optional Dependencies
+* `GITHUB_API_TOKEN` environment variable - Optional GitHub API token to prevent rate limiting when the release scripts access GitHub API for fetching branch and tag information. If not set, the scripts will still work but may encounter rate limits during frequent usage. See [GitHub documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for creating personal access tokens.
+
 ## Development
 
 ### Using pip-tools
@@ -226,6 +229,8 @@ When new major/minor OSIDB version is released, major/minor release of the osidb
     ```
     $ make release
     ```
+    
+    Note: To avoid GitHub API rate limits, you can optionally set the `GITHUB_API_TOKEN` environment variable before running the script.
 
     This will:
     * compare latest version of OSIDB and bindings (safe check before release)
@@ -262,6 +267,8 @@ When new major/minor OSIDB version is being released, we can do a pre-release of
     ```
     $ make pre-release
     ```
+    
+    Note: To avoid GitHub API rate limits, you can optionally set the `GITHUB_API_TOKEN` environment variable before running the script.
 
     This will:
     * compare latest OSIDB release branch version (release-x.x.x) and bindings version (safe check before release)

--- a/scripts/pre_release.sh
+++ b/scripts/pre_release.sh
@@ -8,8 +8,11 @@ get_new_version() {
     osidb_github_base_link="https://api.github.com/repos/RedHatProductSecurity/osidb"
 
     # Get latest OSIDB release branch name
-    local response=$(curl -s -f "${osidb_github_base_link}/branches" \
-    -f -w 'HTTPSTATUS:%{http_code}\n')
+    local curl_args=(-s -f "${osidb_github_base_link}/branches" -f -w 'HTTPSTATUS:%{http_code}\n')
+    if [ -n "${GITHUB_API_TOKEN}" ]; then
+        curl_args+=(-H "Authorization: Bearer ${GITHUB_API_TOKEN}")
+    fi
+    local response=$(curl "${curl_args[@]}")
 
     local body=$(echo ${response} | sed -E 's/HTTPSTATUS\:[0-9]{3}$//')
     local status=$(echo ${response} | tr -d '\n' | sed -E 's/.*HTTPSTATUS:([0-9]{3})$/\1/')

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,8 +8,11 @@ get_new_version() {
     osidb_github_base_link="https://api.github.com/repos/RedHatProductSecurity/osidb"
 
     # Get latest tagged OSIDB version
-    local response=$(curl -s -f "${osidb_github_base_link}/tags" \
-    -f -w 'HTTPSTATUS:%{http_code}\n')
+    local curl_args=(-s -f "${osidb_github_base_link}/tags" -f -w 'HTTPSTATUS:%{http_code}\n')
+    if [ -n "${GITHUB_API_TOKEN}" ]; then
+        curl_args+=(-H "Authorization: Bearer ${GITHUB_API_TOKEN}")
+    fi
+    local response=$(curl "${curl_args[@]}")
 
     local body=$(echo ${response} | sed -E 's/HTTPSTATUS\:[0-9]{3}$//')
     local status=$(echo ${response} | tr -d '\n' | sed -E 's/.*HTTPSTATUS:([0-9]{3})$/\1/')


### PR DESCRIPTION
This PR:
* adds `GITHUB_API_TOKEN` usage for release scripts to prevent rate limiting accessing the Github APIs