### PR TITLE
Add support for custom user-agent in new_session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - support for providing existing refresh token to session to skip initial auth
+- support for custom user-agent via `user_agent` parameter in `new_session`
 
 ## [5.8.1] - 2026-04-08
 ### Changed

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -15,6 +15,7 @@ A Pythonic way to talk to OSIDB without getting lost in HTTP details.
   - [Create a Session](#create-a-session)
   - [Required Environment Variables](#required-environment-variables)
   - [SSL Configuration](#ssl-configuration)
+  - [Custom User-Agent](#custom-user-agent)
 - [Session Operations](#session-operations)
   - [API Version Control](#api-version-control)
   - [Available Resources and Operations](#available-resources-and-operations)
@@ -244,6 +245,30 @@ session = osidb_bindings.new_session(
     osidb_server_uri="https://osidb.example.com/",
     verify_ssl=False
 )
+```
+
+### Custom User-Agent
+
+By default, the session identifies itself as `osidb-bindings/{version} (python-requests/{version})`. You can pass a custom `user_agent` to make your application identifiable in OSIDB logs:
+
+```python
+session = osidb_bindings.new_session(
+    osidb_server_uri="http://localhost:8000/",
+    user_agent="MyApp v1.0.0 ({bindings-user-agent}) prod",
+)
+```
+
+Use the `{bindings-user-agent}` placeholder to control where the osidb-bindings identity is inserted in your user-agent string. The placeholder is replaced with the full bindings identity:
+
+```text
+MyApp v1.0.0 ({bindings-user-agent}) prod → MyApp v1.0.0 (osidb-bindings/5.8.1 (python-requests/2.32.3)) prod
+my-app ({bindings-user-agent})             → my-app (osidb-bindings/5.8.1 (python-requests/2.32.3))
+```
+
+If no placeholder is present, the osidb-bindings identity is appended:
+
+```text
+my-custom-agent → my-custom-agent osidb-bindings/5.8.1 (python-requests/2.32.3)
 ```
 
 ### Session operations

--- a/osidb_bindings/constants.py
+++ b/osidb_bindings/constants.py
@@ -2,8 +2,15 @@
 osidb-bindings constants
 """
 
+from requests.utils import default_user_agent
+
 OSIDB_BINDINGS_VERSION: str = "5.8.1"
-OSIDB_BINDINGS_USERAGENT: str = f"osidb-bindings-{OSIDB_BINDINGS_VERSION}"
+OSIDB_BINDINGS_USERAGENT: str = (
+    f"osidb-bindings/{OSIDB_BINDINGS_VERSION} ({default_user_agent()})"
+)
+
+# Placeholder keyword that gets replaced with the osidb-bindings identity in custom user-agent strings
+USERAGENT_PLACEHOLDER: str = "{bindings-user-agent}"
 OSIDB_BINDINGS_API_PATH: str = ".bindings.python_client.api"
 OSIDB_BINDINGS_PLACEHOLDER_FIELD: str = (
     f'__placeholder_field{OSIDB_BINDINGS_VERSION.replace(".","")}'

--- a/osidb_bindings/session.py
+++ b/osidb_bindings/session.py
@@ -26,6 +26,7 @@ from .constants import (
     OSIDB_BINDINGS_API_PATH,
     OSIDB_BINDINGS_PLACEHOLDER_FIELD,
     OSIDB_BINDINGS_USERAGENT,
+    USERAGENT_PLACEHOLDER,
 )
 from .exceptions import (
     MissingEndpointMethod,
@@ -84,7 +85,12 @@ def promote_flaw(self, id, *args, api_version: str | None = None, **kwargs):
 
 
 def reject_flaw(
-    self, id: str, form_data: dict[str, Any], *args, api_version: str | None = None, **kwargs
+    self,
+    id: str,
+    form_data: dict[str, Any],
+    *args,
+    api_version: str | None = None,
+    **kwargs,
 ):
     method_module = self._get_method_module(
         resource_name="flaws",
@@ -199,6 +205,7 @@ def new_session(
     username=None,
     verify_ssl=True,
     refresh_token=None,
+    user_agent=None,
 ):
     """
     Create a new session for selected OSIDB URI
@@ -219,22 +226,40 @@ def new_session(
         auth=auth,
         verify_ssl=verify_ssl,
         refresh_token=refresh_token,
+        user_agent=user_agent,
     )
 
 
 class Session:
     """Simple session wrapper which encapsulates the client"""
 
-    def __init__(self, base_url, auth=None, verify_ssl=True, refresh_token=None):
+    def __init__(
+        self,
+        base_url,
+        auth=None,
+        verify_ssl=True,
+        refresh_token=None,
+        user_agent: str | None = None,
+    ):
         # Store auth for the refresh token acquirement
         self.auth = auth
         self.refresh_token = refresh_token
         self.endpoints = self.__cache_endpoints()
 
+        if user_agent is not None:
+            if USERAGENT_PLACEHOLDER in user_agent:
+                resolved_user_agent = user_agent.replace(
+                    USERAGENT_PLACEHOLDER, OSIDB_BINDINGS_USERAGENT
+                )
+            else:
+                resolved_user_agent = f"{user_agent} {OSIDB_BINDINGS_USERAGENT}"
+        else:
+            resolved_user_agent = OSIDB_BINDINGS_USERAGENT
+
         self.__client = AuthenticatedClient(
             base_url=base_url,
             headers={
-                "User-Agent": OSIDB_BINDINGS_USERAGENT,
+                "User-Agent": resolved_user_agent,
                 "Bugzilla-Api-Key": get_env("BUGZILLA_API_KEY", ""),
                 "Jira-Api-Key": get_env("JIRA_ACCESS_TOKEN", ""),
                 "Jira-Api-Email": get_env("JIRA_API_EMAIL", ""),
@@ -383,16 +408,12 @@ class Session:
             for endpoint_name in module.ENDPOINT_NAMES:
                 match = pattern.match(endpoint_name)
                 if match:
-                    endpoints[f"{section_name}_api"][match.group(2)].add(
-                        match.group(1)
-                    )
+                    endpoints[f"{section_name}_api"][match.group(2)].add(match.group(1))
 
         return endpoints
 
     def status(self):
-        api_version = self.get_latest_endpoint_version(
-            "osidb", "status", "retrieve"
-        )
+        api_version = self.get_latest_endpoint_version("osidb", "status", "retrieve")
         status_module = importlib.import_module(
             f"{OSIDB_BINDINGS_API_PATH}.osidb.osidb_api_{api_version}_status_retrieve",
             package="osidb_bindings",


### PR DESCRIPTION
This PR adds option to specify custom user agent for osidb-bindings. One can either follow the suggested format or use custom format and just have the osidb-bindings format be appended to it.