### PR TITLE
allow re-using the existing refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- support for providing existing refresh token to session to skip initial auth
 
 ## [5.8.1] - 2026-04-08
 ### Changed

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -130,6 +130,50 @@ Used for OSIDB instances with Kerberos authentication enabled (production/stagin
 session = osidb_bindings.new_session(osidb_server_uri="https://osidb-prod.example.com/")
 ```
 
+#### Reusing a Refresh Token
+
+In distributed environments (e.g. multiple OCP pods or workers),
+each session normally authenticates independently which can cause unnecessary load on the OSIDB server.
+To avoid this, you can authenticate once and share the refresh token across workers via the `refresh_token` parameter:
+
+```python
+# Worker A: authenticate normally and share the refresh token
+session = osidb_bindings.new_session(osidb_server_uri="https://osidb-prod.example.com/")
+token = session.refresh_token  # store in Redis, env var, shared volume, etc.
+
+# Workers B, C, D: skip authentication by reusing the token
+session = osidb_bindings.new_session(
+    osidb_server_uri="https://osidb-prod.example.com/",
+    refresh_token=token,
+)
+```
+
+When a provided refresh token expires, the session will automatically fall back to re-authenticating
+using the configured authentication method (Kerberos or username/password).
+
+> **Note on token expiry in distributed environments:** The refresh token typically lives ~24 hours.
+> When it expires, each worker that holds the stale token will re-authenticate independently on its
+> next request. The token refresh happens lazily — `session.refresh_token` is only updated during
+> the first API call that encounters the expired token, not at session creation time. To keep the
+> new token available for other workers, write it back to shared storage after the first API call, eg.:
+>
+> ```python
+> def fetch_flaw(uri, flaw_id, redis_client):
+>     token = redis_client.get("osidb_refresh_token")
+>     session = osidb_bindings.new_session(uri, refresh_token=token)
+>     flaw = session.flaws.retrieve(flaw_id)
+>
+>     # Write back the token if it was refreshed during the call
+>     if session.refresh_token != token:
+>         redis_client.set("osidb_refresh_token", session.refresh_token)
+>
+>     return flaw
+> ```
+>
+> In the worst case (all workers hit the expired token at the same time), each will
+> re-authenticate and update the shared token once. This happens at most once per token
+> lifetime (~24h). For stricter control, use a distributed lock etc.
+
 ### Required Environment Variables
 
 Certain operations (primarily those involving creating or modifying content) require additional API keys to work properly:

--- a/osidb_bindings/session.py
+++ b/osidb_bindings/session.py
@@ -198,8 +198,14 @@ def new_session(
     password=None,
     username=None,
     verify_ssl=True,
+    refresh_token=None,
 ):
-    """Create a new session for selected OSIDB URI"""
+    """
+    Create a new session for selected OSIDB URI
+
+    Provide an existing refresh token to skip
+    the initial authentication & authorization
+    """
 
     if username and password:
         # OSIDB instances with the username/password auth for token acquirement
@@ -209,16 +215,20 @@ def new_session(
         auth = "kerberos"
 
     return Session(
-        base_url=osidb_server_uri.strip("/"), auth=auth, verify_ssl=verify_ssl
+        base_url=osidb_server_uri.strip("/"),
+        auth=auth,
+        verify_ssl=verify_ssl,
+        refresh_token=refresh_token,
     )
 
 
 class Session:
     """Simple session wrapper which encapsulates the client"""
 
-    def __init__(self, base_url, auth=None, verify_ssl=True):
+    def __init__(self, base_url, auth=None, verify_ssl=True, refresh_token=None):
         # Store auth for the refresh token acquirement
         self.auth = auth
+        self.refresh_token = refresh_token
         self.endpoints = self.__cache_endpoints()
 
         self.__client = AuthenticatedClient(
@@ -341,7 +351,8 @@ class Session:
             allowed_operations=("retrieve", "list"),
         )
 
-        self.refresh_token = self.__get_refresh_token()
+        if self.refresh_token is None:
+            self.refresh_token = self.__get_refresh_token()
 
     def get_latest_endpoint_version(
         self, api_section: str, resource_name: str, method: str


### PR DESCRIPTION
especially for the distributed environments it may not be easily possible to share the session itself but creating completely new one is a costly operation

the creation of the mechanism of sharing the token is a responsibility of the bindings library user