### PR TITLE
Add from_model method for crossmodel conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `from_model` classmethod on all models for creating a model instance from another model instance
 
 ## [5.9.0] - 2026-04-14
 

--- a/osidb_bindings/bindings/python_client/models/affect.py
+++ b/osidb_bindings/bindings/python_client/models/affect.py
@@ -681,6 +681,10 @@ class Affect(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_bulk_post_put_response.py
+++ b/osidb_bindings/bindings/python_client/models/affect_bulk_post_put_response.py
@@ -73,6 +73,10 @@ class AffectBulkPostPutResponse(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_bulk_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_bulk_put_request.py
@@ -380,6 +380,10 @@ class AffectBulkPutRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_cvss.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss.py
@@ -241,6 +241,10 @@ class AffectCVSS(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_cvss_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvss_request.py
@@ -150,6 +150,10 @@ class AffectCVSSRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_cvssv2.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvssv2.py
@@ -241,6 +241,10 @@ class AffectCVSSV2(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_cvssv2_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvssv2_post_request.py
@@ -130,6 +130,10 @@ class AffectCVSSV2PostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_cvssv2_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_cvssv2_put_request.py
@@ -155,6 +155,10 @@ class AffectCVSSV2PutRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_post_request.py
@@ -477,6 +477,10 @@ class AffectPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/affect_report_data.py
@@ -183,6 +183,10 @@ class AffectReportData(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_request.py
+++ b/osidb_bindings/bindings/python_client/models/affect_request.py
@@ -502,6 +502,10 @@ class AffectRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_v1.py
+++ b/osidb_bindings/bindings/python_client/models/affect_v1.py
@@ -498,6 +498,10 @@ class AffectV1(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/affect_v1_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/affect_v1_report_data.py
@@ -192,6 +192,10 @@ class AffectV1ReportData(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/alert.py
+++ b/osidb_bindings/bindings/python_client/models/alert.py
@@ -129,6 +129,10 @@ class Alert(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/audit.py
+++ b/osidb_bindings/bindings/python_client/models/audit.py
@@ -132,6 +132,10 @@ class Audit(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/auth_token_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_create_response_200.py
@@ -103,6 +103,10 @@ class AuthTokenCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/auth_token_refresh_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_refresh_create_response_200.py
@@ -94,6 +94,10 @@ class AuthTokenRefreshCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/auth_token_refresh_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_refresh_retrieve_response_200.py
@@ -94,6 +94,10 @@ class AuthTokenRefreshRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/auth_token_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_retrieve_response_200.py
@@ -103,6 +103,10 @@ class AuthTokenRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/auth_token_verify_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/auth_token_verify_create_response_200.py
@@ -85,6 +85,10 @@ class AuthTokenVerifyCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200.py
@@ -128,6 +128,10 @@ class CollectorsApiV1StatusRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item.py
@@ -226,6 +226,10 @@ class CollectorsApiV1StatusRetrieveResponse200CollectorsItem(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item_error_type_0.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_api_v1_status_retrieve_response_200_collectors_item_error_type_0.py
@@ -43,6 +43,10 @@ class CollectorsApiV1StatusRetrieveResponse200CollectorsItemErrorType0(OSIDBMode
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/collectors_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_healthy_retrieve_response_200.py
@@ -85,6 +85,10 @@ class CollectorsHealthyRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/collectors_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/collectors_retrieve_response_200.py
@@ -96,6 +96,10 @@ class CollectorsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/comment.py
+++ b/osidb_bindings/bindings/python_client/models/comment.py
@@ -162,6 +162,10 @@ class Comment(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/comment_request.py
+++ b/osidb_bindings/bindings/python_client/models/comment_request.py
@@ -96,6 +96,10 @@ class CommentRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/epss.py
+++ b/osidb_bindings/bindings/python_client/models/epss.py
@@ -58,6 +58,10 @@ class EPSS(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/erratum.py
+++ b/osidb_bindings/bindings/python_client/models/erratum.py
@@ -132,6 +132,10 @@ class Erratum(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploit_only_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/exploit_only_report_data.py
@@ -145,6 +145,10 @@ class ExploitOnlyReportData(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_collect_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_collect_update_response_200.py
@@ -94,6 +94,10 @@ class ExploitsApiV1CollectUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200.py
@@ -120,6 +120,10 @@ class ExploitsApiV1CveMapRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200_cves.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_cve_map_retrieve_response_200_cves.py
@@ -37,6 +37,10 @@ class ExploitsApiV1CveMapRetrieveResponse200Cves(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_epss_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_epss_list_response_200.py
@@ -167,6 +167,10 @@ class ExploitsApiV1EpssListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_flaw_data_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_flaw_data_list_response_200.py
@@ -167,6 +167,10 @@ class ExploitsApiV1FlawDataListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_data_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_data_list_response_200.py
@@ -167,6 +167,10 @@ class ExploitsApiV1ReportDataListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200.py
@@ -224,6 +224,10 @@ class ExploitsApiV1ReportDateRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_action_required_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_action_required_item.py
@@ -37,6 +37,10 @@ class ExploitsApiV1ReportDateRetrieveResponse200ActionRequiredItem(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_no_action_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_no_action_item.py
@@ -37,6 +37,10 @@ class ExploitsApiV1ReportDateRetrieveResponse200NoActionItem(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_not_relevant_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_date_retrieve_response_200_not_relevant_item.py
@@ -37,6 +37,10 @@ class ExploitsApiV1ReportDateRetrieveResponse200NotRelevantItem(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200.py
@@ -138,6 +138,10 @@ class ExploitsApiV1ReportExplanationsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200_explanations_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_explanations_retrieve_response_200_explanations_item.py
@@ -43,6 +43,10 @@ class ExploitsApiV1ReportExplanationsRetrieveResponse200ExplanationsItem(OSIDBMo
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200.py
@@ -137,6 +137,10 @@ class ExploitsApiV1ReportPendingRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200_pending_actions_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_report_pending_retrieve_response_200_pending_actions_item.py
@@ -41,6 +41,10 @@ class ExploitsApiV1ReportPendingRetrieveResponse200PendingActionsItem(OSIDBModel
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_status_retrieve_response_200.py
@@ -112,6 +112,10 @@ class ExploitsApiV1StatusRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v1_supported_products_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v1_supported_products_list_response_200.py
@@ -167,6 +167,10 @@ class ExploitsApiV1SupportedProductsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_flaw_data_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_flaw_data_list_response_200.py
@@ -167,6 +167,10 @@ class ExploitsApiV2FlawDataListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200.py
@@ -224,6 +224,10 @@ class ExploitsApiV2ReportDateRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200_action_required_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200_action_required_item.py
@@ -37,6 +37,10 @@ class ExploitsApiV2ReportDateRetrieveResponse200ActionRequiredItem(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200_no_action_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200_no_action_item.py
@@ -37,6 +37,10 @@ class ExploitsApiV2ReportDateRetrieveResponse200NoActionItem(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200_not_relevant_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_date_retrieve_response_200_not_relevant_item.py
@@ -37,6 +37,10 @@ class ExploitsApiV2ReportDateRetrieveResponse200NotRelevantItem(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_explanations_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_explanations_retrieve_response_200.py
@@ -138,6 +138,10 @@ class ExploitsApiV2ReportExplanationsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_explanations_retrieve_response_200_explanations_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_explanations_retrieve_response_200_explanations_item.py
@@ -43,6 +43,10 @@ class ExploitsApiV2ReportExplanationsRetrieveResponse200ExplanationsItem(OSIDBMo
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_pending_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_pending_retrieve_response_200.py
@@ -137,6 +137,10 @@ class ExploitsApiV2ReportPendingRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_pending_retrieve_response_200_pending_actions_item.py
+++ b/osidb_bindings/bindings/python_client/models/exploits_api_v2_report_pending_retrieve_response_200_pending_actions_item.py
@@ -41,6 +41,10 @@ class ExploitsApiV2ReportPendingRetrieveResponse200PendingActionsItem(OSIDBModel
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw.py
+++ b/osidb_bindings/bindings/python_client/models/flaw.py
@@ -882,6 +882,10 @@ class Flaw(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment.py
@@ -196,6 +196,10 @@ class FlawAcknowledgment(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_post_request.py
@@ -102,6 +102,10 @@ class FlawAcknowledgmentPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_put_request.py
@@ -127,6 +127,10 @@ class FlawAcknowledgmentPutRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_acknowledgment_request.py
@@ -114,6 +114,10 @@ class FlawAcknowledgmentRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_classification.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_classification.py
@@ -66,6 +66,10 @@ class FlawClassification(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_collaborator.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_collaborator.py
@@ -119,6 +119,10 @@ class FlawCollaborator(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_collaborator_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_collaborator_post_request.py
@@ -127,6 +127,10 @@ class FlawCollaboratorPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_collaborator_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_collaborator_request.py
@@ -119,6 +119,10 @@ class FlawCollaboratorRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_comment.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment.py
@@ -205,6 +205,10 @@ class FlawComment(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_comment_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_comment_post_request.py
@@ -110,6 +110,10 @@ class FlawCommentPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss.py
@@ -241,6 +241,10 @@ class FlawCVSS(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_post_request.py
@@ -153,6 +153,10 @@ class FlawCVSSPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_put_request.py
@@ -178,6 +178,10 @@ class FlawCVSSPutRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_cvss_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvss_request.py
@@ -150,6 +150,10 @@ class FlawCVSSRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_cvssv2.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvssv2.py
@@ -241,6 +241,10 @@ class FlawCVSSV2(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_cvssv2_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvssv2_post_request.py
@@ -130,6 +130,10 @@ class FlawCVSSV2PostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_cvssv2_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_cvssv2_put_request.py
@@ -155,6 +155,10 @@ class FlawCVSSV2PutRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_label.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_label.py
@@ -59,6 +59,10 @@ class FlawLabel(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version.py
@@ -178,6 +178,10 @@ class FlawPackageVersion(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version_post_request.py
@@ -123,6 +123,10 @@ class FlawPackageVersionPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_package_version_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_package_version_put_request.py
@@ -148,6 +148,10 @@ class FlawPackageVersionPutRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_post_request.py
@@ -705,6 +705,10 @@ class FlawPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_put.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_put.py
@@ -882,6 +882,10 @@ class FlawPut(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_put_classification.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_put_classification.py
@@ -66,6 +66,10 @@ class FlawPutClassification(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_reference.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference.py
@@ -204,6 +204,10 @@ class FlawReference(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_post_request.py
@@ -116,6 +116,10 @@ class FlawReferencePostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_put_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_put_request.py
@@ -141,6 +141,10 @@ class FlawReferencePutRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_reference_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_reference_request.py
@@ -122,6 +122,10 @@ class FlawReferenceRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_report_data.py
@@ -94,6 +94,10 @@ class FlawReportData(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_request.py
@@ -728,6 +728,10 @@ class FlawRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_uuid_list_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_uuid_list_request.py
@@ -98,6 +98,10 @@ class FlawUUIDListRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_v1.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_v1.py
@@ -882,6 +882,10 @@ class FlawV1(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_v1_classification.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_v1_classification.py
@@ -66,6 +66,10 @@ class FlawV1Classification(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_v1_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_v1_report_data.py
@@ -94,6 +94,10 @@ class FlawV1ReportData(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_v1_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_v1_request.py
@@ -728,6 +728,10 @@ class FlawV1Request(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_version.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_version.py
@@ -50,6 +50,10 @@ class FlawVersion(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/flaw_version_request.py
+++ b/osidb_bindings/bindings/python_client/models/flaw_version_request.py
@@ -50,6 +50,10 @@ class FlawVersionRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/incident_request_request.py
+++ b/osidb_bindings/bindings/python_client/models/incident_request_request.py
@@ -84,6 +84,10 @@ class IncidentRequestRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/integration_token_get.py
+++ b/osidb_bindings/bindings/python_client/models/integration_token_get.py
@@ -79,6 +79,10 @@ class IntegrationTokenGet(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/module_component.py
+++ b/osidb_bindings/bindings/python_client/models/module_component.py
@@ -118,6 +118,10 @@ class ModuleComponent(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1AffectsCvssScoresListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_cvss_scores_retrieve_response_200.py
@@ -283,6 +283,10 @@ class OsidbApiV1AffectsCvssScoresRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1AffectsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_affects_retrieve_response_200.py
@@ -540,6 +540,10 @@ class OsidbApiV1AffectsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1AlertsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_alerts_retrieve_response_200.py
@@ -173,6 +173,10 @@ class OsidbApiV1AlertsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1AuditListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_audit_retrieve_response_200.py
@@ -175,6 +175,10 @@ class OsidbApiV1AuditRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_204.py
@@ -85,6 +85,10 @@ class OsidbApiV1AvailableFlawsRetrieveResponse204(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_400.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_400.py
@@ -85,6 +85,10 @@ class OsidbApiV1AvailableFlawsRetrieveResponse400(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_404.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_available_flaws_retrieve_response_404.py
@@ -85,6 +85,10 @@ class OsidbApiV1AvailableFlawsRetrieveResponse404(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_create_response_201.py
@@ -238,6 +238,10 @@ class OsidbApiV1FlawsAcknowledgmentsCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_destroy_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsAcknowledgmentsDestroyResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1FlawsAcknowledgmentsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_retrieve_response_200.py
@@ -238,6 +238,10 @@ class OsidbApiV1FlawsAcknowledgmentsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_acknowledgments_update_response_200.py
@@ -238,6 +238,10 @@ class OsidbApiV1FlawsAcknowledgmentsUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_create_response_201.py
@@ -247,6 +247,10 @@ class OsidbApiV1FlawsCommentsCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1FlawsCommentsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_comments_retrieve_response_200.py
@@ -247,6 +247,10 @@ class OsidbApiV1FlawsCommentsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_create_response_201.py
@@ -924,6 +924,10 @@ class OsidbApiV1FlawsCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_create_response_201.py
@@ -283,6 +283,10 @@ class OsidbApiV1FlawsCvssScoresCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_destroy_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsCvssScoresDestroyResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1FlawsCvssScoresListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_retrieve_response_200.py
@@ -283,6 +283,10 @@ class OsidbApiV1FlawsCvssScoresRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_cvss_scores_update_response_200.py
@@ -283,6 +283,10 @@ class OsidbApiV1FlawsCvssScoresUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_incident_requests_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_incident_requests_create_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsIncidentRequestsCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_create_response_201.py
@@ -163,6 +163,10 @@ class OsidbApiV1FlawsLabelsCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_destroy_response_204.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsLabelsDestroyResponse204(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1FlawsLabelsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_retrieve_response_200.py
@@ -163,6 +163,10 @@ class OsidbApiV1FlawsLabelsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_labels_update_response_200.py
@@ -163,6 +163,10 @@ class OsidbApiV1FlawsLabelsUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1FlawsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_create_response_201.py
@@ -220,6 +220,10 @@ class OsidbApiV1FlawsPackageVersionsCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_destroy_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsPackageVersionsDestroyResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1FlawsPackageVersionsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_retrieve_response_200.py
@@ -220,6 +220,10 @@ class OsidbApiV1FlawsPackageVersionsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_package_versions_update_response_200.py
@@ -220,6 +220,10 @@ class OsidbApiV1FlawsPackageVersionsUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_promote_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_promote_create_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsPromoteCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_create_response_201.py
@@ -246,6 +246,10 @@ class OsidbApiV1FlawsReferencesCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_destroy_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsReferencesDestroyResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1FlawsReferencesListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_retrieve_response_200.py
@@ -246,6 +246,10 @@ class OsidbApiV1FlawsReferencesRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_references_update_response_200.py
@@ -246,6 +246,10 @@ class OsidbApiV1FlawsReferencesUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_reject_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_reject_create_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsRejectCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_reset_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_reset_create_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsResetCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_retrieve_response_200.py
@@ -924,6 +924,10 @@ class OsidbApiV1FlawsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_revert_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_revert_create_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1FlawsRevertCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_flaws_update_response_200.py
@@ -924,6 +924,10 @@ class OsidbApiV1FlawsUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1LabelsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_labels_retrieve_response_200.py
@@ -103,6 +103,10 @@ class OsidbApiV1LabelsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_manifest_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_manifest_retrieve_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV1ManifestRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_schema_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_schema_retrieve_response_200.py
@@ -37,6 +37,10 @@ class OsidbApiV1SchemaRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200.py
@@ -139,6 +139,10 @@ class OsidbApiV1StatusRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_data.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_data.py
@@ -49,6 +49,10 @@ class OsidbApiV1StatusRetrieveResponse200OsidbData(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_service.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_status_retrieve_response_200_osidb_service.py
@@ -37,6 +37,10 @@ class OsidbApiV1StatusRetrieveResponse200OsidbService(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_sync_managers_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_sync_managers_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1SyncManagersListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_sync_managers_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_sync_managers_retrieve_response_200.py
@@ -341,6 +341,10 @@ class OsidbApiV1SyncManagersRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV1TrackersListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v1_trackers_retrieve_response_200.py
@@ -448,6 +448,10 @@ class OsidbApiV1TrackersRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_bulk_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_bulk_create_response_200.py
@@ -118,6 +118,10 @@ class OsidbApiV2AffectsBulkCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_bulk_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_bulk_destroy_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV2AffectsBulkDestroyResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_bulk_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_bulk_update_response_200.py
@@ -118,6 +118,10 @@ class OsidbApiV2AffectsBulkUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_create_response_201.py
@@ -723,6 +723,10 @@ class OsidbApiV2AffectsCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_create_response_201.py
@@ -283,6 +283,10 @@ class OsidbApiV2AffectsCvssScoresCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_destroy_response_204.py
@@ -85,6 +85,10 @@ class OsidbApiV2AffectsCvssScoresDestroyResponse204(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV2AffectsCvssScoresListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_retrieve_response_200.py
@@ -283,6 +283,10 @@ class OsidbApiV2AffectsCvssScoresRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_cvss_scores_update_response_200.py
@@ -283,6 +283,10 @@ class OsidbApiV2AffectsCvssScoresUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_destroy_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_destroy_response_200.py
@@ -85,6 +85,10 @@ class OsidbApiV2AffectsDestroyResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV2AffectsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_retrieve_response_200.py
@@ -723,6 +723,10 @@ class OsidbApiV2AffectsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_affects_update_response_200.py
@@ -723,6 +723,10 @@ class OsidbApiV2AffectsUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_create_response_201.py
@@ -924,6 +924,10 @@ class OsidbApiV2FlawsCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_create_response_201.py
@@ -283,6 +283,10 @@ class OsidbApiV2FlawsCvssScoresCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_destroy_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_destroy_response_204.py
@@ -85,6 +85,10 @@ class OsidbApiV2FlawsCvssScoresDestroyResponse204(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV2FlawsCvssScoresListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_retrieve_response_200.py
@@ -283,6 +283,10 @@ class OsidbApiV2FlawsCvssScoresRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_cvss_scores_update_response_200.py
@@ -283,6 +283,10 @@ class OsidbApiV2FlawsCvssScoresUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV2FlawsListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_retrieve_response_200.py
@@ -924,6 +924,10 @@ class OsidbApiV2FlawsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_flaws_update_response_200.py
@@ -924,6 +924,10 @@ class OsidbApiV2FlawsUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_create_response_201.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_create_response_201.py
@@ -439,6 +439,10 @@ class OsidbApiV2TrackersCreateResponse201(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_list_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_list_response_200.py
@@ -167,6 +167,10 @@ class OsidbApiV2TrackersListResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_retrieve_response_200.py
@@ -448,6 +448,10 @@ class OsidbApiV2TrackersRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_update_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_api_v2_trackers_update_response_200.py
@@ -448,6 +448,10 @@ class OsidbApiV2TrackersUpdateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_healthy_retrieve_response_200.py
@@ -85,6 +85,10 @@ class OsidbHealthyRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_integrations_partial_update_response_204.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_integrations_partial_update_response_204.py
@@ -85,6 +85,10 @@ class OsidbIntegrationsPartialUpdateResponse204(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_integrations_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_integrations_retrieve_response_200.py
@@ -124,6 +124,10 @@ class OsidbIntegrationsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/osidb_whoami_retrieve_response_200.py
@@ -136,6 +136,10 @@ class OsidbWhoamiRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/package.py
+++ b/osidb_bindings/bindings/python_client/models/package.py
@@ -112,6 +112,10 @@ class Package(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/package_request.py
+++ b/osidb_bindings/bindings/python_client/models/package_request.py
@@ -83,6 +83,10 @@ class PackageRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/package_ver.py
+++ b/osidb_bindings/bindings/python_client/models/package_ver.py
@@ -51,6 +51,10 @@ class PackageVer(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/package_ver_request.py
+++ b/osidb_bindings/bindings/python_client/models/package_ver_request.py
@@ -51,6 +51,10 @@ class PackageVerRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_cvss_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_cvss_list.py
@@ -122,6 +122,10 @@ class PaginatedAffectCVSSList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_cvssv2_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_cvssv2_list.py
@@ -122,6 +122,10 @@ class PaginatedAffectCVSSV2List(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_list.py
@@ -122,6 +122,10 @@ class PaginatedAffectList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_affect_v1_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_affect_v1_list.py
@@ -122,6 +122,10 @@ class PaginatedAffectV1List(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_alert_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_alert_list.py
@@ -122,6 +122,10 @@ class PaginatedAlertList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_audit_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_audit_list.py
@@ -122,6 +122,10 @@ class PaginatedAuditList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_epss_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_epss_list.py
@@ -122,6 +122,10 @@ class PaginatedEPSSList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_exploit_only_report_data_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_exploit_only_report_data_list.py
@@ -122,6 +122,10 @@ class PaginatedExploitOnlyReportDataList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_acknowledgment_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_acknowledgment_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawAcknowledgmentList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_collaborator_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_collaborator_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawCollaboratorList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_comment_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_comment_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawCommentList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_cvss_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_cvss_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawCVSSList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_cvssv2_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_cvssv2_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawCVSSV2List(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_label_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_label_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawLabelList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_package_version_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_package_version_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawPackageVersionList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_reference_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_reference_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawReferenceList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_report_data_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_report_data_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawReportDataList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_v1_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_v1_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawV1List(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_flaw_v1_report_data_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_flaw_v1_report_data_list.py
@@ -122,6 +122,10 @@ class PaginatedFlawV1ReportDataList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_supported_products_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_supported_products_list.py
@@ -122,6 +122,10 @@ class PaginatedSupportedProductsList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_sync_manager_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_sync_manager_list.py
@@ -122,6 +122,10 @@ class PaginatedSyncManagerList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_tracker_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_tracker_list.py
@@ -122,6 +122,10 @@ class PaginatedTrackerList(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/paginated_tracker_v1_list.py
+++ b/osidb_bindings/bindings/python_client/models/paginated_tracker_v1_list.py
@@ -122,6 +122,10 @@ class PaginatedTrackerV1List(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/patched_integration_token_patch_request.py
+++ b/osidb_bindings/bindings/python_client/models/patched_integration_token_patch_request.py
@@ -82,6 +82,10 @@ class PatchedIntegrationTokenPatchRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/profile.py
+++ b/osidb_bindings/bindings/python_client/models/profile.py
@@ -58,6 +58,10 @@ class Profile(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/ps_stream_selection.py
+++ b/osidb_bindings/bindings/python_client/models/ps_stream_selection.py
@@ -85,6 +85,10 @@ class PsStreamSelection(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/reject_request.py
+++ b/osidb_bindings/bindings/python_client/models/reject_request.py
@@ -62,6 +62,10 @@ class RejectRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/stream_component.py
+++ b/osidb_bindings/bindings/python_client/models/stream_component.py
@@ -107,6 +107,10 @@ class StreamComponent(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/supported_products.py
+++ b/osidb_bindings/bindings/python_client/models/supported_products.py
@@ -49,6 +49,10 @@ class SupportedProducts(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/sync_manager.py
+++ b/osidb_bindings/bindings/python_client/models/sync_manager.py
@@ -298,6 +298,10 @@ class SyncManager(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/token_obtain_pair.py
+++ b/osidb_bindings/bindings/python_client/models/token_obtain_pair.py
@@ -58,6 +58,10 @@ class TokenObtainPair(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/token_obtain_pair_request.py
+++ b/osidb_bindings/bindings/python_client/models/token_obtain_pair_request.py
@@ -74,6 +74,10 @@ class TokenObtainPairRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/token_refresh.py
+++ b/osidb_bindings/bindings/python_client/models/token_refresh.py
@@ -49,6 +49,10 @@ class TokenRefresh(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/token_refresh_request.py
+++ b/osidb_bindings/bindings/python_client/models/token_refresh_request.py
@@ -61,6 +61,10 @@ class TokenRefreshRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/token_verify_request.py
+++ b/osidb_bindings/bindings/python_client/models/token_verify_request.py
@@ -61,6 +61,10 @@ class TokenVerifyRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker.py
+++ b/osidb_bindings/bindings/python_client/models/tracker.py
@@ -406,6 +406,10 @@ class Tracker(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker_post.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_post.py
@@ -397,6 +397,10 @@ class TrackerPost(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker_post_request.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_post_request.py
@@ -166,6 +166,10 @@ class TrackerPostRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker_report_data.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_report_data.py
@@ -84,6 +84,10 @@ class TrackerReportData(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker_request.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_request.py
@@ -170,6 +170,10 @@ class TrackerRequest(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker_suggestion.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_suggestion.py
@@ -104,6 +104,10 @@ class TrackerSuggestion(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker_suggestion_v1.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_suggestion_v1.py
@@ -104,6 +104,10 @@ class TrackerSuggestionV1(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/tracker_v1.py
+++ b/osidb_bindings/bindings/python_client/models/tracker_v1.py
@@ -406,6 +406,10 @@ class TrackerV1(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/trackers_api_v1_file_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/trackers_api_v1_file_create_response_200.py
@@ -149,6 +149,10 @@ class TrackersApiV1FileCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/trackers_api_v2_file_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/trackers_api_v2_file_create_response_200.py
@@ -149,6 +149,10 @@ class TrackersApiV2FileCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/user.py
+++ b/osidb_bindings/bindings/python_client/models/user.py
@@ -91,6 +91,10 @@ class User(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_adjust_create_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_adjust_create_response_200.py
@@ -85,6 +85,10 @@ class WorkflowsApiV1WorkflowsAdjustCreateResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_2_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_2_response_200.py
@@ -85,6 +85,10 @@ class WorkflowsApiV1WorkflowsRetrieve2Response200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_api_v1_workflows_retrieve_response_200.py
@@ -85,6 +85,10 @@ class WorkflowsApiV1WorkflowsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/workflows_healthy_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_healthy_retrieve_response_200.py
@@ -85,6 +85,10 @@ class WorkflowsHealthyRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/bindings/python_client/models/workflows_retrieve_response_200.py
+++ b/osidb_bindings/bindings/python_client/models/workflows_retrieve_response_200.py
@@ -85,6 +85,10 @@ class WorkflowsRetrieveResponse200(OSIDBModel):
     def new(cls):
         return cls.from_dict({})
 
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())

--- a/osidb_bindings/templates_0.22.0/model.py.jinja
+++ b/osidb_bindings/templates_0.22.0/model.py.jinja
@@ -209,6 +209,13 @@ return field_dict
 
     {# CHANGE END (4) #}
 
+    {# CHANGE START (6) - add classmethod for creating model from another model instance #}
+    @classmethod
+    def from_model(cls: type[T], model: "OSIDBModel") -> T:
+        return cls.from_dict(model.to_dict())
+
+    {# CHANGE END (6) #}
+
     {% if model.additional_properties %}
     @property
     def additional_keys(self) -> list[str]:


### PR DESCRIPTION
This PR adds convenient `from_model` method to convert between related models (eg. response model into normal model, etc.)