### PR TITLE
OSIDB-5228: Add refresh token file caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- automatic refresh token file caching to avoid re-authentication on every `new_session()` call
 
 ## [5.12.0] - 2026-07-03
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -131,6 +131,31 @@ Used for OSIDB instances with Kerberos authentication enabled (production/stagin
 session = osidb_bindings.new_session(osidb_server_uri="https://osidb-prod.example.com/")
 ```
 
+#### Refresh Token Caching
+
+By default, the bindings automatically cache the refresh token to a file on disk.
+This means subsequent `new_session()` calls skip the initial authentication
+and reuse the cached token instead, reducing load on the server. The cache
+persists across script runs, so even independent processes benefit from it.
+
+The cache is transparent. If the cached token has expired, the session automatically
+re-authenticates and updates the cache file.
+
+To disable caching:
+
+```python
+session = osidb_bindings.new_session(
+    osidb_server_uri="https://osidb-prod.example.com/",
+    token_cache_enabled=False,
+)
+```
+
+The cache directory is resolved in the following order:
+1. `OSIDB_BINDINGS_CACHE_DIR` environment variable (useful for custom cache locations)
+2. `$XDG_CACHE_HOME/osidb-bindings/`
+3. `~/.cache/osidb-bindings/`
+4. System temp directory fallback (e.g. `/tmp/osidb-bindings-cache-<uid>/`)
+
 #### Reusing a Refresh Token
 
 In distributed environments (e.g. multiple OCP pods or workers),

--- a/osidb_bindings/session.py
+++ b/osidb_bindings/session.py
@@ -37,6 +37,7 @@ from .exceptions import (
 )
 from .helpers import get_env, parse_version_key
 from .iterators import Paginator
+from .token_cache import TokenCache, resolve_kerberos_principal
 
 MAX_CONCURRENCY = get_env("OSIDB_BINDINGS_MAX_CONCURRENCY", "10", is_int=True)
 
@@ -200,13 +201,14 @@ def serialize_data(data, model):
 
 
 def new_session(
-    osidb_server_uri,
-    password=None,
-    username=None,
-    verify_ssl=True,
-    refresh_token=None,
-    user_agent=None,
-):
+    osidb_server_uri: str,
+    password: str | None = None,
+    username: str | None = None,
+    verify_ssl: bool = True,
+    refresh_token: str | None = None,
+    user_agent: str | None = None,
+    token_cache_enabled: bool = True,
+) -> "Session":
     """
     Create a new session for selected OSIDB URI
 
@@ -227,6 +229,7 @@ def new_session(
         verify_ssl=verify_ssl,
         refresh_token=refresh_token,
         user_agent=user_agent,
+        token_cache_enabled=token_cache_enabled,
     )
 
 
@@ -235,16 +238,29 @@ class Session:
 
     def __init__(
         self,
-        base_url,
-        auth=None,
-        verify_ssl=True,
-        refresh_token=None,
+        base_url: str,
+        auth: tuple[str, str] | str | None = None,
+        verify_ssl: bool = True,
+        refresh_token: str | None = None,
         user_agent: str | None = None,
+        token_cache_enabled: bool = True,
     ):
         # Store auth for the refresh token acquirement
         self.auth = auth
         self.refresh_token = refresh_token
         self.endpoints = self.__cache_endpoints()
+        if token_cache_enabled:
+            if isinstance(auth, tuple):
+                identity = auth[0]
+            elif auth == "kerberos":
+                identity = resolve_kerberos_principal()
+            else:
+                identity = None
+            self.token_cache: TokenCache | None = TokenCache(
+                server_url=base_url, identity=identity
+            )
+        else:
+            self.token_cache = None
 
         if user_agent is not None:
             if USERAGENT_PLACEHOLDER in user_agent:
@@ -377,7 +393,16 @@ class Session:
         )
 
         if self.refresh_token is None:
-            self.refresh_token = self.__get_refresh_token()
+            cached = self.token_cache.read() if self.token_cache else None
+            if cached is not None:
+                self.refresh_token = cached
+            else:
+                self.refresh_token = self.__get_refresh_token()
+                if self.token_cache:
+                    self.token_cache.write(self.refresh_token)
+        else:
+            if self.token_cache:
+                self.token_cache.write(self.refresh_token)
 
     def get_latest_endpoint_version(
         self, api_section: str, resource_name: str, method: str
@@ -450,6 +475,8 @@ class Session:
         except requests.HTTPError:
             # expired refresh token, renew it and try again
             self.refresh_token = self.__get_refresh_token()
+            if self.token_cache:
+                self.token_cache.write(self.refresh_token)
             response = auth_token_refresh_create.sync(
                 client=self.__client,
                 body=models.TokenRefreshRequest.from_dict(

--- a/osidb_bindings/token_cache.py
+++ b/osidb_bindings/token_cache.py
@@ -1,0 +1,164 @@
+"""
+osidb-bindings refresh token file cache
+"""
+
+import base64
+import datetime
+import hashlib
+import json
+import os
+import tempfile
+import time
+from functools import cached_property
+from pathlib import Path
+
+from .helpers import get_env
+
+CACHE_SUBDIR: str = "osidb-bindings"
+CACHE_VERSION: int = 1
+# owner read/write/execute, no access for group or others
+CACHE_DIR_PERMISSIONS: int = 0o700
+# owner read/write only, no access for group or others
+CACHE_FILE_PERMISSIONS: int = 0o600
+
+
+def resolve_kerberos_principal() -> str | None:
+    """Read the default Kerberos principal from the local credential cache."""
+    try:
+        import gssapi
+
+        cred = gssapi.Credentials(usage="initiate")
+        return str(cred.name)
+    except Exception as e:
+        print(
+            f"WARNING: Failed to resolve Kerberos principal: {e}. "
+            "Token cache will not be scoped to identity."
+        )
+        return None
+
+
+class TokenCache:
+    """Manages reading/writing refresh tokens to disk cache files."""
+
+    def __init__(self, server_url: str, identity: str | None = None) -> None:
+        self.server_url: str = server_url
+        self.identity: str | None = identity
+
+    @cached_property
+    def cache_dir(self) -> Path | None:
+        """Resolve the cache directory, trying several locations in order."""
+        candidates: list[Path] = []
+
+        env_dir: str | None = get_env("OSIDB_BINDINGS_CACHE_DIR")
+        if env_dir:
+            candidates.append(Path(env_dir))
+
+        xdg_cache: str | None = get_env("XDG_CACHE_HOME")
+        if xdg_cache:
+            candidates.append(Path(xdg_cache) / CACHE_SUBDIR)
+
+        try:
+            candidates.append(Path.home() / ".cache" / CACHE_SUBDIR)
+        except (RuntimeError, OSError):
+            pass
+
+        candidates.append(
+            Path(tempfile.gettempdir()) / f"{CACHE_SUBDIR}-cache-{os.getuid()}"
+        )
+
+        for candidate in candidates:
+            try:
+                candidate.mkdir(parents=True, exist_ok=True, mode=CACHE_DIR_PERMISSIONS)
+                st = candidate.stat()
+                if st.st_uid != os.getuid():
+                    continue
+                return candidate
+            except OSError:
+                continue
+
+        return None
+
+    @cached_property
+    def cache_key(self) -> str:
+        """Generate a filesystem-safe cache key from the server URL."""
+        normalized: str = self.server_url.lower().rstrip("/")
+        if self.identity:
+            normalized += f"|{self.identity}"
+        return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+    def cache_file(self) -> Path | None:
+        if self.cache_dir is None:
+            return None
+        return self.cache_dir / f"{self.cache_key}.json"
+
+    @staticmethod
+    def is_token_expired(token: str) -> bool:
+        """Check if a JWT token has expired by decoding its payload."""
+        try:
+            payload: str = token.split(".")[1]
+            payload += "=" * (4 - len(payload) % 4)
+            claims: dict = json.loads(base64.urlsafe_b64decode(payload))
+            return claims["exp"] < time.time()
+        except Exception:
+            return True
+
+    def read(self) -> str | None:
+        """Read cached refresh token, or None if absent/invalid/expired/unreadable."""
+        path: Path | None = self.cache_file()
+        if path is None or not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            if not isinstance(data, dict):
+                return None
+            if data.get("version") != CACHE_VERSION:
+                return None
+            token: str | None = data.get("refresh_token")
+            if token is None or self.is_token_expired(token):
+                return None
+            return token
+        except Exception as e:
+            print(
+                f"WARNING: Token cache read failed: {e}. "
+                "To disable caching, pass token_cache_enabled=False to new_session()."
+            )
+            return None
+
+    def write(self, token: str) -> None:
+        """Write refresh token to cache file with restrictive permissions."""
+        path: Path | None = self.cache_file()
+        if path is None:
+            return
+        tmp_path: Path = path.with_suffix(f".tmp.{os.getpid()}")
+        try:
+            data: str = json.dumps(
+                {
+                    "version": CACHE_VERSION,
+                    "server_url": self.server_url,
+                    "refresh_token": token,
+                    "created_at": datetime.datetime.now(
+                        datetime.timezone.utc
+                    ).isoformat(),
+                }
+            )
+            # create or overwrite file, write-only, with permissions set atomically
+            fd: int = os.open(
+                tmp_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                CACHE_FILE_PERMISSIONS,
+            )
+            os.chmod(tmp_path, CACHE_FILE_PERMISSIONS)
+            try:
+                os.write(fd, data.encode())
+            finally:
+                os.close(fd)
+            os.replace(tmp_path, path)
+        except Exception as e:
+            print(
+                f"WARNING: Token cache write failed: {e}. "
+                "To disable caching, pass token_cache_enabled=False to new_session()."
+            )
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass


### PR DESCRIPTION
This PR adds refresh token file caching so clients won't hammer OSIDB with LDAP auth requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic refresh-token caching to reduce repeated authentication when creating sessions.
  - Cached tokens are refreshed and updated automatically when they expire.
  - Added an option to disable token caching when creating a session.
  - Cache location can be configured through environment settings, with secure platform-specific defaults.

- **Documentation**
  - Added guidance covering token caching, configuration, cache locations, and disabling the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->